### PR TITLE
update remote catalog url to be not gcs anymore

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/CatalogDefinitionsConfig.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/CatalogDefinitionsConfig.java
@@ -15,7 +15,7 @@ public class CatalogDefinitionsConfig {
       SEED_SUBDIRECTORY + LOCAL_CONNECTOR_CATALOG_FILE_NAME;
 
   private static final String REMOTE_OSS_CATALOG_URL =
-      "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json";
+      "https://connectors.airbyte.com/api/v0/catalog/oss_catalog.json";
 
   public static String getLocalConnectorCatalogPath() {
     Optional<String> customCatalogPath = new EnvConfigs().getLocalCatalogPath();

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/CatalogDefinitionsConfig.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/CatalogDefinitionsConfig.java
@@ -15,7 +15,7 @@ public class CatalogDefinitionsConfig {
       SEED_SUBDIRECTORY + LOCAL_CONNECTOR_CATALOG_FILE_NAME;
 
   private static final String REMOTE_OSS_CATALOG_URL =
-      "https://connectors.airbyte.com/api/v0/catalog/oss_catalog.json";
+      "https://connectors.airbyte.com/oss_catalog.json";
 
   public static String getLocalConnectorCatalogPath() {
     Optional<String> customCatalogPath = new EnvConfigs().getLocalCatalogPath();


### PR DESCRIPTION
## What
Use an API to make this more resilient to the underlying technology serving it

## How
This now points to our ELB fronting a "backend bucket" in GCS
