### PR TITLE
pull docs from connectors repo for fe build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,6 +169,7 @@ jobs:
           cd /tmp
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte 
           cp -R airbyte/docs $dir/docs
+          ls -lah $dir/docs
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,7 +48,6 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       build: ${{ steps.filter.outputs.build }}
       cli: ${{ steps.filter.outputs.cli }}
-      connectors: ${{ steps.filter.outputs.connectors }}
       db: ${{ steps.filter.outputs.db }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -163,6 +162,13 @@ jobs:
           org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
+      # TODO: Once we pull these from the metadata service, remove this step
+      - name: Copy docs from connectors repository
+        run: |
+          dir=$PWD
+          cd /tmp
+          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte 
+          cp -R airbyte/docs $dir/docs
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -42,7 +42,7 @@ jobs:
       dev_tag: ${{ steps.set-outputs.outputs.dev_tag }}
       main_tag: ${{ steps.set-outputs.outputs.main_tag }}
     steps:
-      - name: Checkout Airbyte
+      - name: Checkout Airbyte Platform
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.oss_ref || github.ref }}
@@ -82,6 +82,22 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.oss_ref || github.ref }}
+
+      # TODO: Once we pull these from the metadata service, remove this step
+      - name: Copy docs from connectors repository
+        run: |
+          dir=$PWD
+          cd /tmp
+          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte 
+          cp -R airbyte/docs $dir/docs
+          ls -lah $dir/docs
+
+      - name: Build :airbyte-webapp
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
 
       - name: Build Branch
         uses: ./.github/actions/build-branch


### PR DESCRIPTION
## What
This is a temporary solution to enable building docs into the frontend artifact from the connectors repo until connector metadata service is live.

## How
We clone connectors repo HEAD and wholesale copy the entire docs folder over to be consumed by frontend build. This is basically identical to how it worked in the monorepo from the end artifact perspective - though if someone wants to test and work with this behavior locally it forces them to copy over the relevant docs directly - so it is a bit of a DevEx regression.

## Can this PR be safely reverted / rolled back?



*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
We get docs for end users in the platform after this :) 
