### PR TITLE
🪟 🔧 Adjust doc middleware for new repo structure

### DIFF
--- a/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
+++ b/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
@@ -70,7 +70,7 @@ export function docMiddleware(): Plugin {
   console.log(
     `📃 To work with local docs checkout ${chalk.bold.gray(
       "https://github.com/airbytehq/airbyte"
-    )} into ${chalk.bold.gray(path.resolve(__dirname, "../../../../airbyte"))}.\n`
+    )} into ${chalk.bold.gray(AIRBYTE_REPO_PATH)}.\n`
   );
   return remoteDocMiddleware();
 }

--- a/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
+++ b/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
@@ -70,7 +70,7 @@ export function docMiddleware(): Plugin {
   console.log(
     `📃 To work with local docs checkout ${chalk.bold.gray(
       "https://github.com/airbytehq/airbyte"
-    )} in parallel to your ${path.basename(path.resolve(__dirname, "../../.."))} folder.\n`
+    )} into ${chalk.bold.gray(path.resolve(__dirname, "../../../../airbyte"))}.\n`
   );
   return remoteDocMiddleware();
 }

--- a/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
+++ b/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
@@ -1,27 +1,76 @@
-import type { Connect, Plugin } from "vite";
+import type { Connect, Plugin, ViteDevServer } from "vite";
 
+import fs from "fs";
+import path from "path";
+
+import chalk from "chalk";
 import express from "express";
 
-export function docMiddleware(): Plugin {
+const AIRBYTE_REPO_PATH = `${path.resolve(__dirname, "../../../../airbyte")}`;
+const INTEGRATIONS_DOCS_DIR = `${AIRBYTE_REPO_PATH}/docs/integrations`;
+
+const localDocMiddleware = (): Plugin => {
   return {
-    name: "airbyte/doc-middleware",
-    configureServer(server) {
+    name: "airbyte/doc-middleware-local",
+    configureServer(server: ViteDevServer) {
       // Serve the docs used in the sidebar. During building Gradle will copy those into the docker image
       // Relavant gradle task :airbyte-webapp:copyDocs
-      server.middlewares.use(
-        "/docs/integrations",
-        express.static(`${__dirname}/../../../docs/integrations`) as Connect.NextHandleFunction
-      );
+      server.middlewares.use("/docs/integrations", express.static(INTEGRATIONS_DOCS_DIR) as Connect.NextHandleFunction);
       // workaround for adblockers to serve google ads docs in development
       server.middlewares.use(
         "/docs/integrations/sources/gglad.md",
-        express.static(`${__dirname}/../../../docs/integrations/sources/google-ads.md`) as Connect.NextHandleFunction
+        express.static(`${INTEGRATIONS_DOCS_DIR}/sources/google-ads.md`) as Connect.NextHandleFunction
       );
       // Server assets that can be used during. Related gradle task: :airbyte-webapp:copyDocAssets
       server.middlewares.use(
         "/docs/.gitbook",
-        express.static(`${__dirname}/../../../docs/.gitbook`) as Connect.NextHandleFunction
+        express.static(`${AIRBYTE_REPO_PATH}/docs/.gitbook`) as Connect.NextHandleFunction
       );
     },
   };
+};
+
+const remoteDocMiddleware = (): Plugin => {
+  return {
+    name: "airbyte/doc-middleware-remote",
+    config(config, { command }) {
+      if (command !== "build") {
+        return {
+          server: {
+            // Proxy requests to connector docs and assets directly to GitHub to load them from airbytehq/airbyte repository.
+            proxy: {
+              "/docs/integrations": {
+                changeOrigin: true,
+                target: "https://raw.githubusercontent.com/airbytehq/airbyte/master",
+                rewrite: (path) => (path.endsWith("gglad.md") ? path.replace(/\/gglad\.md$/, "/google-ads.md") : path),
+              },
+              "/docs/.gitbook": {
+                changeOrigin: true,
+                target: "https://raw.githubusercontent.com/airbytehq/airbyte/master",
+              },
+            },
+          },
+        };
+      }
+    },
+  };
+};
+
+export function docMiddleware(): Plugin {
+  const isAirbyteCheckedOut = fs.existsSync(INTEGRATIONS_DOCS_DIR) && fs.statSync(INTEGRATIONS_DOCS_DIR).isDirectory();
+
+  if (isAirbyteCheckedOut) {
+    console.log(
+      `📃 Connector docs are served ${chalk.bold.cyan("locally")} from ${chalk.green(INTEGRATIONS_DOCS_DIR)}.\n`
+    );
+    return localDocMiddleware();
+  }
+
+  console.log(`📃 Connector docs are served ${chalk.bold.magenta("remotely")} from GitHub.`);
+  console.log(
+    `📃 To work with local docs checkout ${chalk.bold.gray(
+      "https://github.com/airbytehq/airbyte"
+    )} in parallel to your ${path.basename(path.resolve(__dirname, "../../.."))} folder.\n`
+  );
+  return remoteDocMiddleware();
 }


### PR DESCRIPTION
## What

Since the connector docs are no longer part of `airbyte-platform`, but only of `airbytehq/airbyte`, we can't always load them locally during development of the frontend anymore.

This adjusts our middleware so that:

* if you don't have the `airbytehq/airbyte` repository checked out in parallel, the docs are loaded from GitHub directly.
* If you have the repository checked out in parallel, docs will load from the parallel checked out repository locally, so you can make edits and preview it directly.

You'll see a message on the command line indicating which mode you're running in:

![screenshot-20230220-112331](https://user-images.githubusercontent.com/877229/220079048-35bbc714-8b6e-409a-a144-0eadff72d3f4.png)

![screenshot-20230220-112352](https://user-images.githubusercontent.com/877229/220079113-92f13171-4604-4666-8103-a9911671bf15.png)
