### PR TITLE
update docs to include airbyte-platform migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Explore our [demo app](https://demo.airbyte.io/).
 
 ### Run Airbyte locally
 
-You can run Airbyte locally with Docker.
+You can run Airbyte locally with Docker. The shell script below will retrieve the requisite docker files from the [platform repository](https://github.com/airbytehq/airbyte-platform) and run docker compose for you.
 
 ```bash
 git clone --depth 1 https://github.com/airbytehq/airbyte.git
 cd airbyte
-docker compose up
+./run-ab-platform.sh
 ```
 
 Login to the web app at [http://localhost:8000](http://localhost:8000) by entering the default credentials found in your .env file.
@@ -81,7 +81,11 @@ Sign up for [Airbyte Cloud](https://cloud.airbyte.io/signup).
 
 Get started by checking Github issues and creating a Pull Request. An easy way to start contributing is to update an existing connector or create a new connector using the low-code and Python CDKs. You can find the code for existing connectors in the [connectors](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors) directory. The Airbyte platform is written in Java, and the frontend in React. You can also contribute to our docs and tutorials. Advanced Airbyte users can apply to the [Maintainer program](https://airbyte.com/maintainer-program) and [Writer Program](https://airbyte.com/write-for-the-community).
 
-Read the [Contributing guide](https://docs.airbyte.com/contributing-to-airbyte/).
+If you would like to make a contribution to the platform itself, please refer to guides in [the platform repository](https://github.com/airbytehq/airbyte-platform).
+
+If you have an existing pull request in airbytehq/airbyte that should be migrated to airbyte-platform, please follow [the guide in this document](https://docs.airbyte.com/contributing-to-airbyte/).
+
+Read the [Contributing guide](https://docs.airbyte.com/contributing-to-airbyte/working-with-airbyte-platform).
 
 ## Reporting vulnerabilities
 

--- a/docs/contributing-to-airbyte/working-with-airbyte-platform.md
+++ b/docs/contributing-to-airbyte/working-with-airbyte-platform.md
@@ -1,0 +1,72 @@
+---
+description: Working with Airbyte Platform
+---
+
+# Overview
+
+In order to facilitate faster development workflows, airbytehq/airbyte was split into two repositories on 2023-19-02:
+
+- airbytehq/airbyte connectors and development around
+- airbytehq/airbyte-platform the codebase that facilitates connectors
+- airbytehq/airbyte-protocol used by both connectors and platform, the underlying protocol that airbyte uses to perform data transfers
+
+If you have an existing pull request in airbytehq/airbyte that should instead target airbyte-platform there are two ways that you can move it over
+
+# Migrating from airbytehq/airbyte
+
+1. Using our /create-platform-pr [slash command tool](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/create-oss-pr-snapshot.yml) for platform. Simply comment "create-platform-pr" on your existing airbytehq/airbyte pull request and let our automation perform the migration for you. Note that if there are any conflicts between files, for the purposes of simplicity the tool will always use your version of the file in the pull request vs the version that exists in airbyte-platform.
+2. Manually migrate your pull request. If you have a pull request that is touching both connectors and platform code, for instance, you may need to perform this step manually. The steps to do so are below:
+
+- First, fork airbyte-platform:
+
+
+Let's start with the name of your branch on airbytehq/airbyte, called my-old-pr-branch. First, add airbyte-platform as a new remote in airbytehq/airbyte, and add your new fork as well as a remote.
+
+```bash
+cd airbyte
+git remote add platform git@github.com:airbytehq/airbyte-platform.git
+git remote add platform-fork git@github.com:my-github-username/airbyte-platform.git
+```
+
+- check out main and create a new branch from airbyte-platform main for your pull request in airbyte-platform
+
+```bash
+git fetch platform main 
+git checkout main 
+git checkout -b my-new-pr-branch
+```
+
+- check out your old pr branch and get the commits that need to be carried over
+```bash
+git checkout my-old-pr-branch 
+git log
+```
+Copy each commit SHA that you need to pull over. Example:
+
+```bash
+commit f1bab07d25a118e0f347869e6bc8b3820ba757e4 (HEAD -> master, origin/master, origin/HEAD)
+Author: Conor <cpdeethree@users.noreply.github.com>
+Date:   Mon Feb 20 08:29:48 2023 -0600
+
+    remove airbyte-commons-temporal/worker-models (#23239)
+    
+    * remove airbyte-commons-temporal
+    
+    * remove airbyte-worker-models
+
+```
+
+In this case you want "f1bab07d25a118e0f347869e6bc8b3820ba757e4"
+
+Then, checkout my-new-pr-branch again and cherry-pick the commit(s) you want over to my-new-pr-branch
+
+```bash
+git checkout my-new-pr-branch 
+git cherry-pick f1bab07d25a118e0f347869e6bc8b3820ba757e4
+```
+
+Finally, once all your commits have been brought over, you can push your new branch up to your airbyte-platform fork and open a new pull request 
+
+```bash
+git push platform-fork my-new-pr-branch
+```

--- a/docs/contributing-to-airbyte/working-with-airbyte-platform.md
+++ b/docs/contributing-to-airbyte/working-with-airbyte-platform.md
@@ -10,68 +10,9 @@ In order to facilitate faster development workflows, airbytehq/airbyte was split
 - airbytehq/airbyte-platform the codebase that facilitates connectors
 - airbytehq/airbyte-protocol used by both connectors and platform, the underlying protocol that airbyte uses to perform data transfers
 
-If you have an existing pull request in airbytehq/airbyte that should instead target airbyte-platform there are two ways that you can move it over
-
-# Issues and Pull Requests
-
-Please open issues in airbytehq/airbyte and tag them platform. Issues have been disabled on airbyte-platform in order to keep issue tracking in one centralized location
-Please open pull requests targeting airbytehq/airbyte-platform in airbytehq/airbyte-platform and reference the issue in airbytehq/airbyte
+If you have an existing pull request in airbytehq/airbyte that should instead target airbyte-platform you can use our tool mentioned below to perform the migration.
 
 # Migrating from airbytehq/airbyte
 
-1. Using our /create-platform-pr [slash command tool](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/create-oss-pr-snapshot.yml) for platform. Simply comment "create-platform-pr" on your existing airbytehq/airbyte pull request and let our automation perform the migration for you. Note that if there are any conflicts between files, for the purposes of simplicity the tool will always use your version of the file in the pull request vs the version that exists in airbyte-platform.
-2. Manually migrate your pull request. If you have a pull request that is touching both connectors and platform code, for instance, you may need to perform this step manually. The steps to do so are below:
+Using our /create-platform-pr [slash command tool](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/create-oss-pr-snapshot.yml) for platform. Simply comment "create-platform-pr" on your existing airbytehq/airbyte pull request and let our automation perform the migration for you. Note that if there are any conflicts between files, for the purposes of simplicity the tool will always use your version of the file in the pull request vs the version that exists in airbyte-platform.
 
-- First, fork airbyte-platform:
-
-
-Let's start with the name of your branch on airbytehq/airbyte, called my-old-pr-branch. First, add airbyte-platform as a new remote in airbytehq/airbyte, and add your new fork as well as a remote.
-
-```bash
-cd airbyte
-git remote add platform git@github.com:airbytehq/airbyte-platform.git
-git remote add platform-fork git@github.com:my-github-username/airbyte-platform.git
-```
-
-- check out main and create a new branch from airbyte-platform main for your pull request in airbyte-platform
-
-```bash
-git fetch platform main 
-git checkout main 
-git checkout -b my-new-pr-branch
-```
-
-- check out your old pr branch and get the commits that need to be carried over
-```bash
-git checkout my-old-pr-branch 
-git log
-```
-Copy each commit SHA that you need to pull over. Example:
-
-```bash
-commit f1bab07d25a118e0f347869e6bc8b3820ba757e4 (HEAD -> master, origin/master, origin/HEAD)
-Author: Conor <cpdeethree@users.noreply.github.com>
-Date:   Mon Feb 20 08:29:48 2023 -0600
-
-    remove airbyte-commons-temporal/worker-models (#23239)
-    
-    * remove airbyte-commons-temporal
-    
-    * remove airbyte-worker-models
-
-```
-
-In this case you want "f1bab07d25a118e0f347869e6bc8b3820ba757e4"
-
-Then, checkout my-new-pr-branch again and cherry-pick the commit(s) you want over to my-new-pr-branch
-
-```bash
-git checkout my-new-pr-branch 
-git cherry-pick f1bab07d25a118e0f347869e6bc8b3820ba757e4
-```
-
-Finally, once all your commits have been brought over, you can push your new branch up to your airbyte-platform fork and open a new pull request 
-
-```bash
-git push platform-fork my-new-pr-branch
-```

--- a/docs/contributing-to-airbyte/working-with-airbyte-platform.md
+++ b/docs/contributing-to-airbyte/working-with-airbyte-platform.md
@@ -12,6 +12,11 @@ In order to facilitate faster development workflows, airbytehq/airbyte was split
 
 If you have an existing pull request in airbytehq/airbyte that should instead target airbyte-platform there are two ways that you can move it over
 
+# Issues and Pull Requests
+
+Please open issues in airbytehq/airbyte and tag them platform. Issues have been disabled on airbyte-platform in order to keep issue tracking in one centralized location
+Please open pull requests targeting airbytehq/airbyte-platform in airbytehq/airbyte-platform and reference the issue in airbytehq/airbyte
+
 # Migrating from airbytehq/airbyte
 
 1. Using our /create-platform-pr [slash command tool](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/create-oss-pr-snapshot.yml) for platform. Simply comment "create-platform-pr" on your existing airbytehq/airbyte pull request and let our automation perform the migration for you. Note that if there are any conflicts between files, for the purposes of simplicity the tool will always use your version of the file in the pull request vs the version that exists in airbyte-platform.


### PR DESCRIPTION
## What
This pr contains updates to README to reference airbyte-platform as well as migration instructions if you have an existing pull request and need to move it over to airbyte-platform

## How
Update README.md and add a new doc
