### PR TITLE
fix: missing from configmap

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -72,4 +72,6 @@ data:
   WORKER_STATE_STORAGE_TYPE:  {{ .Values.global.state.storage.type | quote }}
   SHOULD_RUN_NOTIFY_WORKFLOWS: "false"
   MAX_NOTIFY_WORKERS: {{ .Values.worker.maxNotifyWorkers | default "5" | quote }}
+  STRICT_COMPARISON_NORMALIZATION_TAG: ""
+  STRICT_COMPARISON_NORMALIZATION_WORKSPACES: ""
 {{- end }}


### PR DESCRIPTION
## What

Migrated from https://github.com/airbytehq/airbyte/pull/22697

Issue of missing STRICT_COMPARISON_NORMALIZATION_WORKSPACES and STRICT_COMPARISON_NORMALIZATION_TAG from configmap helm chart:

https://github.com/airbytehq/airbyte/issues/22687


## How
Add missing configs in env.