### PR TITLE
🪟 🔧 Enable local docs for airbyte-platform-internal

### DIFF
--- a/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
+++ b/airbyte-webapp/packages/vite-plugins/doc-middleware.ts
@@ -6,25 +6,22 @@ import path from "path";
 import chalk from "chalk";
 import express from "express";
 
-const AIRBYTE_REPO_PATH = `${path.resolve(__dirname, "../../../../airbyte")}`;
-const INTEGRATIONS_DOCS_DIR = `${AIRBYTE_REPO_PATH}/docs/integrations`;
-
-const localDocMiddleware = (): Plugin => {
+const localDocMiddleware = (docsPath: string): Plugin => {
   return {
     name: "airbyte/doc-middleware-local",
     configureServer(server: ViteDevServer) {
       // Serve the docs used in the sidebar. During building Gradle will copy those into the docker image
       // Relavant gradle task :airbyte-webapp:copyDocs
-      server.middlewares.use("/docs/integrations", express.static(INTEGRATIONS_DOCS_DIR) as Connect.NextHandleFunction);
+      server.middlewares.use("/docs/integrations", express.static(docsPath) as Connect.NextHandleFunction);
       // workaround for adblockers to serve google ads docs in development
       server.middlewares.use(
         "/docs/integrations/sources/gglad.md",
-        express.static(`${INTEGRATIONS_DOCS_DIR}/sources/google-ads.md`) as Connect.NextHandleFunction
+        express.static(`${docsPath}/sources/google-ads.md`) as Connect.NextHandleFunction
       );
       // Server assets that can be used during. Related gradle task: :airbyte-webapp:copyDocAssets
       server.middlewares.use(
         "/docs/.gitbook",
-        express.static(`${AIRBYTE_REPO_PATH}/docs/.gitbook`) as Connect.NextHandleFunction
+        express.static(`${docsPath}/docs/.gitbook`) as Connect.NextHandleFunction
       );
     },
   };
@@ -56,21 +53,43 @@ const remoteDocMiddleware = (): Plugin => {
   };
 };
 
-export function docMiddleware(): Plugin {
-  const isAirbyteCheckedOut = fs.existsSync(INTEGRATIONS_DOCS_DIR) && fs.statSync(INTEGRATIONS_DOCS_DIR).isDirectory();
+const getDocsIntegrationPath = (searchPath: string): string => {
+  return path.resolve(__dirname, searchPath, "airbyte/docs/integrations");
+};
 
-  if (isAirbyteCheckedOut) {
-    console.log(
-      `📃 Connector docs are served ${chalk.bold.cyan("locally")} from ${chalk.green(INTEGRATIONS_DOCS_DIR)}.\n`
-    );
-    return localDocMiddleware();
+/**
+ * Tries to find the airbytehq/airbyte repository checked out in parallel to the current repository
+ * for serving docs locally. Returns {@code null} if it can't be found.
+ */
+const getLocalDocsPath = (): string | null => {
+  // If running inside airbyte-platform this file is nested 4 folders deep into the repository
+  const usingAirbytePlatformPath = getDocsIntegrationPath("../../../../");
+  if (fs.existsSync(usingAirbytePlatformPath) && fs.statSync(usingAirbytePlatformPath).isDirectory()) {
+    return usingAirbytePlatformPath;
+  }
+
+  // If running inside airbyte-platform-internal this file is nested 5 folders deep into the repository
+  const usingAirbytePlatformInternalPath = getDocsIntegrationPath("../../../../../");
+  if (fs.existsSync(usingAirbytePlatformInternalPath) && fs.statSync(usingAirbytePlatformInternalPath).isDirectory()) {
+    return usingAirbytePlatformInternalPath;
+  }
+
+  return null;
+};
+
+export function docMiddleware(): Plugin {
+  const localPath = getLocalDocsPath();
+
+  if (localPath) {
+    console.log(`📃 Connector docs are served ${chalk.bold.cyan("locally")} from ${chalk.green(localPath)}.\n`);
+    return localDocMiddleware(localPath);
   }
 
   console.log(`📃 Connector docs are served ${chalk.bold.magenta("remotely")} from GitHub.`);
   console.log(
     `📃 To work with local docs checkout ${chalk.bold.gray(
       "https://github.com/airbytehq/airbyte"
-    )} into ${chalk.bold.gray(AIRBYTE_REPO_PATH)}.\n`
+    )} next to your ${chalk.bold.gray("airbyte-platform")} or ${chalk.bold.gray("airbyte-platform-internal")} folder.\n`
   );
   return remoteDocMiddleware();
 }


### PR DESCRIPTION
## What

This PR ensures that serving local docs will work no matter if you're running from `airbyte-platform` or `airbyte-platform-internal` (which will be the case next week). In `airbyte-platform-internal` the OSS code will be nested under `/oss` and thus we need to look one folder higher to find the parallel checked out `airbyte` folder for local serving docs.

This PR tries both pathes now. We decided for the simple path checking solution over actually using git to retrieve the root command, to also work in case users would download the files via zip and not have a git repository instantiated.