### PR TITLE
(test CI) helm: add externalDatabase.jdbcUrl configuration

### DIFF
--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -177,10 +177,14 @@ Add environment variables to configure database values
 Add environment variables to configure database values
 */}}
 {{- define "airbyte.database.url" -}}
+{{- if .Values.externalDatabase.jdbcUrl -}}
+{{- .Values.externalDatabase.jdbcUrl -}}
+{{- else -}}
 {{- $host := (include "airbyte.database.host" .) -}}
 {{- $dbName := (include "airbyte.database.name" .) -}}
 {{- $port := (include "airbyte.database.port" . ) -}}
 {{- printf "jdbc:postgresql://%s:%s/%s" $host $port $dbName -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1240,6 +1240,7 @@ postgresql:
 ##  externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the DB password
 ##  externalDatabase.database Database name
 ##  externalDatabase.port Database port number
+##  externalDatabase.jdbcUrl Database full JDBL URL (ex: jdbc:postgresql://host:port/db?parameters)
 ##
 externalDatabase:
   host: localhost
@@ -1249,6 +1250,7 @@ externalDatabase:
   existingSecretPasswordKey: ""
   database: db-airbyte
   port: 5432
+  jdbcUrl: ""
 
 ## @section Logs parameters
 


### PR DESCRIPTION
Allows overriding the DATABASE_URL environment variable in the Helm componen This allows helm charts to connect to an external database that require parameters such as SSL mode.

Migrated-From: airbytehq/airbyte#22521
Fixes: airbytehq/airbyte#17995

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.java`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [ ] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
