### PR TITLE
remove optional user from Workspace context

### DIFF
--- a/airbyte-featureflag/src/main/kotlin/Client.kt
+++ b/airbyte-featureflag/src/main/kotlin/Client.kt
@@ -248,10 +248,5 @@ private fun Context.toLDContext(): LDContext {
         builder.anonymous(true)
     }
 
-    when (this) {
-        is Workspace -> user?.let { builder.set("user", it) }
-        else -> Unit
-    }
-
     return builder.build()
 }

--- a/airbyte-featureflag/src/main/kotlin/Context.kt
+++ b/airbyte-featureflag/src/main/kotlin/Context.kt
@@ -80,22 +80,16 @@ data class Multi(val contexts: List<Context>) : Context {
  * Context for representing a workspace.
  *
  * @param [key] the unique identifying value of this workspace
- * @param [user] an optional user identifier
  */
-data class Workspace @JvmOverloads constructor(
-    override val key: String,
-    val user: String? = null
-) : Context {
+data class Workspace constructor(override val key: String) : Context {
     override val kind = "workspace"
 
     /**
      * Secondary constructor
      *
      * @param [key] workspace UUID
-     * @param [user] an optional user identifier
      */
-    @JvmOverloads
-    constructor(key: UUID, user: String? = null) : this(key = key.toString(), user = user)
+    constructor(key: UUID) : this(key = key.toString())
 }
 
 /**

--- a/airbyte-featureflag/src/test/kotlin/ContextTest.kt
+++ b/airbyte-featureflag/src/test/kotlin/ContextTest.kt
@@ -77,10 +77,9 @@ class MultiTest {
 class WorkspaceTest {
     @Test
     fun `verify data`() {
-        Workspace("workspace key", "user").also {
+        Workspace("workspace key").also {
             assert(it.kind == "workspace")
             assert(it.key == "workspace key")
-            assert(it.user == "user")
         }
     }
 }


### PR DESCRIPTION
## What
- remove `user` attribute from `Workspace` context
    - this was a left-over from an early version of the feature-flag client which only adds confusion

## How
- 🔪 
