### PR TITLE
use PAT instead of GITHUB_TOKEN for test_reporter action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Airbyte Platform CI
+name: Airbyte CI
 
 env:
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
@@ -16,9 +16,11 @@ on:
           - "true"
           - "false"
         required: false
+  schedule:
+    - cron: "0 */1 * * *"
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 permissions: write-all
@@ -48,6 +50,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       build: ${{ steps.filter.outputs.build }}
       cli: ${{ steps.filter.outputs.cli }}
+      connectors: ${{ steps.filter.outputs.connectors }}
       db: ${{ steps.filter.outputs.db }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -72,12 +75,16 @@ jobs:
               - 'deps.toml'
             cli:
               - 'airbyte-api/**'
+              - 'octavia-cli/**'
+            connectors:
+              - 'airbyte-cdk/**'
+              - 'airbyte-protocol/**'
+              - 'airbyte-integrations/**'
+              - 'airbyte-commons-worker/**'
             db:
               - 'airbyte-db/**'
             frontend:
               - 'airbyte-api/src/main/openapi/config.yaml'
-              - 'airbyte-connector-builder-server/CDK_VERSION'
-              - 'airbyte-connector-builder-server/src/main/openapi/openapi.yaml'
               - 'airbyte-webapp/**'
               - 'airbyte-webapp-e2e-tests/**'
 
@@ -92,6 +99,259 @@ jobs:
   #          echo '${{ toJSON(needs) }}'
 
   ## BUILDS
+  octavia-cli-build:
+    needs: changes
+    runs-on: ubuntu-latest
+    # Because scheduled builds on master require us to skip the changes job. Use always() to force this to run on master.
+    if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.build == 'true' || (always() && github.ref == 'refs/heads/master')
+    name: "Octavia CLI: Build"
+    timeout-minutes: 90
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}
+          cache-python: "false"
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Set up CI Gradle Properties
+        run: |
+          mkdir -p ~/.gradle/
+          cat > ~/.gradle/gradle.properties <<EOF
+          org.gradle.jvmargs=-Xmx8g -Xss4m \
+            --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
+          org.gradle.vfs.watch=false
+          EOF
+
+      - name: Format
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=OCTAVIA_CLI ./gradlew format --scan --info --stacktrace
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - name: Ensure no file change
+        run: ./tools/bin/check_for_file_changes
+
+      - name: Build
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - name: Build Platform Docker Images
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - name: Run integration tests
+        uses: Wandalen/wretry.action@master
+        with:
+          command: ./tools/bin/integration_tests_octavia.sh
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+  # Connectors Base
+  # In case of self-hosted EC2 errors, remove this block.
+  start-connectors-base-build-runner:
+    name: "Connectors Base: Start Build EC2 Runner"
+    needs:
+      - changes
+    # Because scheduled builds on master require us to skip the changes job. Use always() to force this to run on master.
+    if: |
+      needs.changes.outputs.build == 'true' || needs.changes.outputs.connectors == 'true' || needs.changes.outputs.db == 'true' || (always() && github.ref == 'refs/heads/master')
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Start AWS Runner
+        id: start-ec2-runner
+        uses: ./.github/actions/start-aws-runner
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          github-token: ${{ env.PAT }}
+
+  build-connectors-base:
+    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
+    needs: start-connectors-base-build-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-connectors-base-build-runner.outputs.label }} # run the job on the newly created runner
+    name: "Connectors Base: Build"
+    timeout-minutes: 90
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install Pyenv
+        run: python3 -m pip install virtualenv==16.7.9 --user
+
+      - name: Install automake
+        run: apt-get install -y automake build-essential libtool libtool-bin autoconf
+
+      - name: Set up CI Gradle Properties
+        run: |
+          mkdir -p ~/.gradle/
+          cat > ~/.gradle/gradle.properties <<EOF
+          org.gradle.jvmargs=-Xmx8g -Xss4m \
+            --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
+          org.gradle.vfs.watch=false
+          EOF
+
+      - name: Generate Template scaffold
+        uses: Wandalen/wretry.action@master
+        with:
+          command: ./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates --scan
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - name: Format
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=CONNECTORS_BASE ./gradlew format --scan --info --stacktrace
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      # Verify that the linter is happy
+      - name: Ensure no file change from code formatting
+        run: git --no-pager diff && test -z "$(git --no-pager diff)"
+
+      - name: Build
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=CONNECTORS_BASE ./gradlew build --scan
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      # Ensure that the connector autogenerated files are happy
+      - name: Ensure no file change from regenerating connector definitions/specs
+        run: git --no-pager diff && test -z "$(git --no-pager diff)"
+
+      - name: Publish Connectors Base Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        id: connectors-test-results
+        if: always()
+        with:
+          junit_files: "/actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml\n/actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml"
+          comment_mode: failures
+          json_file: connectors_base_results.json
+          json_test_case_results: true
+          check_name: "Connectors Base Test Results"
+
+      - name: Setup Google Cloud SDK
+        if: always()
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.GKE_TEST_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Prep Test Results For GCS
+        if: always()
+        run: |
+          python tools/bin/prep_test_results_for_gcs.py --json connectors_base_results.json  --jobid $GITHUB_JOB --runid $GITHUB_RUN_ID
+
+      - name: Upload Test Results to GCS
+        if: always()
+        run: |
+          gcs_bucket_name="dev-ab-ci-run-results"
+          filename=$(echo "${{ fromJSON( steps.connectors-test-results.outputs.json ).check_url }}" | sed 's@.*/@@')
+          echo "$filename"
+          gsutil -h "Cache-Control:public" cp connectors_base_results.jsonl "gs://$gcs_bucket_name/oss/$filename.jsonl"
+
+      - name: Generate Test Report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Connectors Base Test Report
+          # Specify top-level and second-level modules. Note there cannot be a space between the comma.
+          path: "/actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml,/actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml"
+          reporter: java-junit
+          fail-on-error: 'false'
+          token: ${{ env.PAT }}
+
+  # In case of self-hosted EC2 errors, remove this block.
+  stop-connectors-base-build-runner:
+    name: "Connectors Base: Stop Build EC2 Runner"
+    timeout-minutes: 10
+    needs:
+      - start-connectors-base-build-runner # required to get output from the start-runner job
+      - build-connectors-base # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    # Always is required to stop the runner even if the previous job has errors. However always() runs even if the previous step is skipped.
+    # Thus, we check for skipped here.
+    if: ${{ always() && needs.start-connectors-base-build-runner.result != 'skipped'}}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Stop EC2 runner
+        uses: supertopher/ec2-github-runner@base64v1.0.10
+        with:
+          mode: stop
+          github-token: ${{ env.PAT }}
+          label: ${{ needs.start-connectors-base-build-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-connectors-base-build-runner.outputs.ec2-instance-id }}
+
   ## Frontend Test
   # In case of self-hosted EC2 errors, remove this block.
   start-frontend-runner:
@@ -162,14 +422,6 @@ jobs:
           org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
-      # TODO: Once we pull these from the metadata service, remove this step
-      - name: Copy docs from connectors repository
-        run: |
-          dir=$PWD
-          cd /tmp
-          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte 
-          cp -R airbyte/docs $dir/docs
-          ls -lah $dir/docs
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master
@@ -276,6 +528,16 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+
+      - name: Delete default old docker and replace it with a new one
+        shell: bash
+        run: |
+          sudo rm /var/lib/dpkg/lock
+          sudo rm /var/lib/dpkg/lock-frontend
+          sudo apt-get remove docker.io || sudo apt-get remove docker
+          curl -fsSL https://get.docker.com | bash -
+          sudo rm -f /var/lib/dpkg/lock
+          sudo rm -f /var/lib/dpkg/lock-frontend
 
       - name: Set up CI Gradle Properties
         run: |
@@ -394,6 +656,16 @@ jobs:
         with:
           node-version: "lts/*"
 
+      - name: Delete default old docker and replace it with a new one
+        shell: bash
+        run: |
+          sudo rm /var/lib/dpkg/lock
+          sudo rm /var/lib/dpkg/lock-frontend
+          sudo apt-get remove docker.io || sudo apt-get remove docker
+          curl -fsSL https://get.docker.com | bash -
+          sudo rm -f /var/lib/dpkg/lock
+          sudo rm -f /var/lib/dpkg/lock-frontend
+
       - name: Set up CI Gradle Properties
         run: |
           mkdir -p ~/.gradle/
@@ -437,6 +709,7 @@ jobs:
             ${{ github.workspace }}/airbyte-bootloader/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-commons/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-commons-cli/build/reports/jacoco/test/jacocoTestReport.xml,
+            ${{ github.workspace }}/airbyte-commons-docker/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-commons-protocol/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-commons-temporal/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-commons-worker/build/reports/jacoco/test/jacocoTestReport.xml,
@@ -452,6 +725,7 @@ jobs:
             ${{ github.workspace }}/airbyte-notification/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-oauth/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-persistence/job-persistence/build/reports/jacoco/test/jacocoTestReport.xml,
+            ${{ github.workspace }}/airbyte-protocol/protocol-models/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-server/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-test-utils/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/airbyte-workers/build/reports/jacoco/test/jacocoTestReport.xml
@@ -461,6 +735,21 @@ jobs:
           title: Airbyte Code Coverage
           update-comment: true
           debug-mode: false
+
+      - name: Integration test
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=PLATFORM ./gradlew newIntegrationTest
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - name: Slow integration test
+        if: contains(github.ref, 'bump-version') || contains(github.ref, 'master')
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=PLATFORM ./gradlew slowIntegrationTest
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
 
       - name: Test if Seed spec is updated
         uses: Wandalen/wretry.action@master
@@ -502,7 +791,7 @@ jobs:
         id: platform-results
         if: always()
         with:
-          junit_files: "/actions-runner/_work/airbyte-platform/airbyte-platform/*/build/test-results/*/*.xml\n/actions-runner/_work/airbyte-platform/airbyte-platform/*/*/build/test-results/*/*.xml"
+          junit_files: "/actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml\n/actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml"
           comment_mode: failures
           json_file: platform_results.json
           json_test_case_results: true
@@ -534,9 +823,10 @@ jobs:
         with:
           name: Platform Test Report with Docker E2E Test
           # Specify top-level and second-level modules. Note there cannot be a space between the comma.
-          path: "/actions-runner/_work/airbyte-platform/airbyte-platform/*/build/test-results/*/*.xml,/actions-runner/_work/airbyte-platform/airbyte-platform/*/*/build/test-results/*/*.xml"
+          path: "/actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml,/actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml"
           reporter: java-junit
           fail-on-error: 'false'
+          token: ${{ env.PAT }}
 
       - name: Upload test results to BuildPulse for flaky test detection
         if: "!cancelled()" # Run this step even when the tests fail. Skip if the workflow is cancelled.
@@ -544,7 +834,7 @@ jobs:
         with:
           account: 59758427
           repository: 283046497
-          path: "/actions-runner/_work/airbyte-platform/airbyte-platform/*"
+          path: "/actions-runner/_work/airbyte/airbyte/*"
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
@@ -581,7 +871,230 @@ jobs:
           label: ${{ needs.start-platform-build-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-platform-build-runner.outputs.ec2-instance-id }}
 
-  # ## Helm Acceptance Tests
+  ## Kube Acceptance Tests
+  # Docker acceptance tests run as part of the build job.
+  # In case of self-hosted EC2 errors, remove this block.
+  start-kube-acceptance-test-runner:
+    name: "Platform: Start Kube Acceptance Test Runner"
+    needs:
+      - changes
+    # Because scheduled builds on master require us to skip the changes job. Use always() to force this to run on master.
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.build == 'true' || (always() && github.ref == 'refs/heads/master')
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Start AWS Runner
+        id: start-ec2-runner
+        uses: ./.github/actions/start-aws-runner
+        with:
+          # github-self-hosted-runner-ubuntu-20-with-150gdisk-docker-20.10.7-and-socat
+          ec2-image-id: ami-0c1a9bc22624339d8
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          github-token: ${{ env.PAT }}
+  kube-acceptance-test:
+    name: "Platform: Acceptance Tests (Kube)"
+    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
+    needs: start-kube-acceptance-test-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
+    environment: more-secrets
+    timeout-minutes: 40
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}
+          cache-python: "false"
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install unzip
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y unzip
+
+      - uses: azure/setup-helm@v3
+        with:
+          version: "latest"
+          token: ${{ secrets.GITHUB_TOKEN }}
+        id: install
+
+      - name: Fix EC-2 Runner
+        run: |
+          mkdir -p /home/runner
+
+      - name: Set up CI Gradle Properties
+        run: |
+          mkdir -p ~/.gradle/
+          cat > ~/.gradle/gradle.properties <<EOF
+          org.gradle.jvmargs=-Xmx8g -Xss4m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
+          org.gradle.vfs.watch=false
+          EOF
+
+      - name: Create cluster config file
+        run: |
+          cat > /tmp/kind-config.yaml <<EOF
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+          - role: worker
+          EOF
+
+      - name: KIND Kubernetes Cluster Setup
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: kindest/node:v1.21.2
+          config: /tmp/kind-config.yaml
+        # In case of self-hosted EC2 errors, remove this env block.
+        env:
+          USER: root
+          HOME: /home/runner
+          CHANGE_MINIKUBE_NONE_USER: true
+
+      - name: Build Platform Docker Images
+        uses: Wandalen/wretry.action@master
+        with:
+          command: SUB_BUILD=PLATFORM ./gradlew assemble -x test --scan
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - name: Run Kubernetes End-to-End Acceptance Tests
+        env:
+          USER: root
+          HOME: /home/runner
+          # AWS_S3_INTEGRATION_TEST_CREDS can be found in LastPass as AWS_S3_INTEGRATION_TEST_CREDS
+          AWS_S3_INTEGRATION_TEST_CREDS: ${{ secrets.AWS_S3_INTEGRATION_TEST_CREDS }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          AWS_S3_BUCKET: airbyte-ci-ac-tests-logs
+          SECRET_STORE_GCP_CREDENTIALS: ${{ secrets.SECRET_STORE_GCP_CREDENTIALS }}
+          SECRET_STORE_GCP_PROJECT_ID: ${{ secrets.SECRET_STORE_GCP_PROJECT_ID }}
+        uses: Wandalen/wretry.action@master
+        with:
+          command: CI=true IS_MINIKUBE=true ./tools/bin/acceptance_test_kube.sh
+          attempt_limit: 3
+          attempt_delay: 5000 # in ms
+
+      - uses: actions/setup-python@v4
+        if: always()
+        with:
+          python-version: "3.9"
+
+      - name: Publish Kube Test Results
+        id: kube-results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          junit_files: "/actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml\n/actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml"
+          comment_mode: failures
+          json_file: kube_results.json
+          json_test_case_results: true
+          check_name: "Kube Test Results"
+
+      - name: Setup Google Cloud SDK
+        if: always()
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.GKE_TEST_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Prep Test Results For GCS
+        if: always()
+        run: |
+          python tools/bin/prep_test_results_for_gcs.py --json kube_results.json  --jobid $GITHUB_JOB --runid $GITHUB_RUN_ID
+
+      - name: Upload Test Results to GCS
+        if: always()
+        run: |
+          gcs_bucket_name="dev-ab-ci-run-results"
+          filename=$(echo "${{ fromJSON( steps.kube-results.outputs.json ).check_url }}" | sed 's@.*/@@')
+          echo "$filename"
+          gsutil -h "Cache-Control:public" cp kube_results.jsonl "gs://$gcs_bucket_name/oss/$filename.jsonl"
+
+      - name: Generate Test Report
+        uses: dorny/test-reporter@v1
+        if: always() # run this step even if previous step failed
+        with:
+          name: Platform Kubernetes E2E Test Report
+          path: "/actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml"
+          reporter: java-junit
+          fail-on-error: 'false'
+          token: ${{ env.PAT }}
+
+      - name: Upload test results to BuildPulse for flaky test detection
+        if: "!cancelled()" # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        uses: Workshop64/buildpulse-action@main
+        with:
+          account: 59758427
+          repository: 283046497
+          path: "/actions-runner/_work/airbyte/airbyte/*"
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Kubernetes Logs
+          path: /tmp/kubernetes_logs/*
+
+  # In case of self-hosted EC2 errors, remove this block.
+  stop-kube-acceptance-test-runner:
+    name: "Platform: Stop Kube Acceptance Test EC2 Runner"
+    timeout-minutes: 10
+    needs:
+      - start-kube-acceptance-test-runner # required to get output from the start-runner job
+      - kube-acceptance-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    # Always is required to stop the runner even if the previous job has errors. However always() runs even if the previous step is skipped.
+    # Thus, we check for skipped here.
+    if: ${{ always() && needs.start-kube-acceptance-test-runner.result != 'skipped'}}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Stop EC2 runner
+        uses: supertopher/ec2-github-runner@base64v1.0.10
+        with:
+          mode: stop
+          github-token: ${{ env.PAT }}
+          label: ${{ needs.start-kube-acceptance-test-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-kube-acceptance-test-runner.outputs.ec2-instance-id }}
+
+  # ## Kube Acceptance Tests
   # # Docker acceptance tests run as part of the build job.
   # # In case of self-hosted EC2 errors, remove this block.
   start-helm-acceptance-test-runner:
@@ -617,21 +1130,22 @@ jobs:
   helm-acceptance-test:
     name: "Platform: Acceptance Tests (Helm)"
     # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
-    needs: [ start-helm-acceptance-test-runner ] # required to start the main job when the runner is ready
+    needs: [start-helm-acceptance-test-runner] # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-helm-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
     # this is the label of the runner
+    environment: more-secrets
     timeout-minutes: 90
     defaults:
       run:
-        working-directory: "/actions-runner/_work/airbyte-platform/airbyte-platform"
+        working-directory: "/actions-runner/_work/airbyte/airbyte"
     env:
-      HOME: /actions-runner/_work/airbyte-platform/airbyte-platform
-      GITHUB_WORKSPACE: /actions-runner/_work/airbyte-platform/airbyte-platform
+      HOME: /actions-runner/_work/airbyte/airbyte
+      GITHUB_WORKSPACE: /actions-runner/_work/airbyte/airbyte
 
     steps:
       - name: Fix EC-2 Runner
         run: |
-          mkdir -p /actions-runner/_work/airbyte-platform/airbyte-platform && mkdir -p /actions-runner/_work/airbyte-platform/airbyte-platform/.kube
+          mkdir -p /actions-runner/_work/airbyte/airbyte && mkdir -p /actions-runner/_work/airbyte/airbyte/.kube
 
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -739,7 +1253,7 @@ jobs:
           AWS_S3_BUCKET: airbyte-ci-ac-tests-logs
           SECRET_STORE_GCP_CREDENTIALS: ${{ secrets.SECRET_STORE_GCP_CREDENTIALS }}
           SECRET_STORE_GCP_PROJECT_ID: ${{ secrets.SECRET_STORE_GCP_PROJECT_ID }}
-        timeout-minutes: 40
+        timeout-minutes: 20
         uses: Wandalen/wretry.action@master
         with:
           command: CI=true IS_MINIKUBE=true ./tools/bin/acceptance_test_kube_helm.sh
@@ -754,6 +1268,7 @@ jobs:
           path: "./*/build/test-results/*/*.xml"
           reporter: java-junit
           fail-on-error: 'false'
+          token: ${{ env.PAT }}
 
       - uses: actions/upload-artifact@v2
         if: failure()
@@ -767,7 +1282,7 @@ jobs:
         with:
           account: 59758427
           repository: 283046497
-          path: "/actions-runner/_work/airbyte-platform/airbyte-platform/*"
+          path: "/actions-runner/_work/airbyte/airbyte/*"
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
@@ -814,8 +1329,11 @@ jobs:
     name: "Notify Slack Channel on Build Failures"
     runs-on: ubuntu-latest
     needs:
+      - build-connectors-base
       - frontend-build
+      - octavia-cli-build
       - platform-build
+      - kube-acceptance-test
       # Todo: Kyryl turn this on.
       # - helm-acceptance-test
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
@@ -846,8 +1364,11 @@ jobs:
     name: "Notify Slack Channel on Build Fixes"
     runs-on: ubuntu-latest
     needs:
+      - build-connectors-base
       - frontend-build
+      - octavia-cli-build
       - platform-build
+      - kube-acceptance-test
       # Todo: Kyryl turn this on.
       # - helm-acceptance-test
     if: success()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Airbyte CI
+name: Airbyte Connectors & Octavia CI
 
 env:
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
@@ -16,8 +16,6 @@ on:
           - "true"
           - "false"
         required: false
-  schedule:
-    - cron: "0 */1 * * *"
   push:
     branches:
       - master
@@ -78,15 +76,10 @@ jobs:
               - 'octavia-cli/**'
             connectors:
               - 'airbyte-cdk/**'
-              - 'airbyte-protocol/**'
               - 'airbyte-integrations/**'
               - 'airbyte-commons-worker/**'
             db:
               - 'airbyte-db/**'
-            frontend:
-              - 'airbyte-api/src/main/openapi/config.yaml'
-              - 'airbyte-webapp/**'
-              - 'airbyte-webapp-e2e-tests/**'
 
   # Uncomment to debug.
   #  changes-output:
@@ -153,13 +146,6 @@ jobs:
         uses: Wandalen/wretry.action@master
         with:
           command: SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
-          attempt_limit: 3
-          attempt_delay: 5000 # in ms
-
-      - name: Build Platform Docker Images
-        uses: Wandalen/wretry.action@master
-        with:
-          command: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
           attempt_limit: 3
           attempt_delay: 5000 # in ms
 
@@ -1330,12 +1316,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-connectors-base
-      - frontend-build
       - octavia-cli-build
-      - platform-build
-      - kube-acceptance-test
-      # Todo: Kyryl turn this on.
-      # - helm-acceptance-test
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout Airbyte
@@ -1365,12 +1346,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-connectors-base
-      - frontend-build
       - octavia-cli-build
-      - platform-build
-      - kube-acceptance-test
-      # Todo: Kyryl turn this on.
-      # - helm-acceptance-test
     if: success()
     steps:
       - name: Get Previous Workflow Status


### PR DESCRIPTION
## What
By default this action uses GITHUB_TOKEN which has a pretty low rate limit. Sometimes it fails for exceeding that rate limit

## How
use env.PAT which is derived from find a pat script instead


source: https://github.com/airbytehq/airbyte/pull/22332