### PR TITLE
remove tasks that moves api docs into docs/ (not relevant in new repo)

### DIFF
--- a/airbyte-api/build.gradle
+++ b/airbyte-api/build.gradle
@@ -163,19 +163,8 @@ task generateApiDocs(type: GenerateTask) {
             generatePom  : "false",
             interfaceOnly: "true"
     ]
-
-    doLast {
-        def target = file(rootProject.file("docs/reference/api/generated-api-html"))
-        delete target
-        mkdir target
-        copy {
-            from outputDir
-            include "**/*.html"
-            includeEmptyDirs = false
-            into target
-        }
-    }
 }
+// todo (cgardens) this should probably be assemble instead of compileJava.
 compileJava.dependsOn tasks.generateApiDocs
 
 dependencies {


### PR DESCRIPTION
## What
* In `airbytehq/airbyte` we moved the api docs into the `docs/` folder so that it could be show in docs.airbyte.com. That's not relevant anymore and docs.airbyte.com does not use these docs anymore anyway.
