### PR TITLE
Fix DATABASE_PASSWORD env for airbyte-metrics helm chart

### DIFF
--- a/charts/airbyte-metrics/templates/deployment.yaml
+++ b/charts/airbyte-metrics/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
         - name: DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.database.secretName | default (include "airbyte.chart" .) }}
-              key: {{ .Values.global.database.secretValue | default "postgresql-password" }}
+              name: {{ .Values.global.database.secretName | default (printf "%s-airbyte-secrets" .Release.Name ) }}
+              key: {{ .Values.global.database.secretValue | default "DATABASE_PASSWORD" }}
         - name: DATABASE_URL
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/23226

Currently the airbyte-metrics pod does not start up due to being unable to find the env. More info in the issue linked above, but I was able to get it to start normally with the change included in this PR.

Maybe this change was meant to be included in https://github.com/airbytehq/airbyte/pull/16131?

## How
This PR brings the airbyte-metrics deployment.yaml template in conformance with other charts pulling this secret.

a couple examples of the pattern used elsewhere that I've copied:

https://github.com/airbytehq/airbyte-platform/blob/15a34b8af95e9dbaf4c07980b3f09d724072dc8b/charts/airbyte-server/templates/deployment.yaml#L77-L81

https://github.com/airbytehq/airbyte-platform/blob/15a34b8af95e9dbaf4c07980b3f09d724072dc8b/charts/airbyte-temporal/templates/deployment.yaml#L72-L76


source: https://github.com/airbytehq/airbyte/pull/23230