### PR TITLE
add activity to fetch feature flags

### DIFF
--- a/airbyte-featureflag/src/main/kotlin/Flags.kt
+++ b/airbyte-featureflag/src/main/kotlin/Flags.kt
@@ -55,7 +55,7 @@ object ShouldFailSyncIfHeartbeatFailure : Temporary(key = "heartbeat.failSync")
  * @param [attrs] optional attributes associated with this flag
  */
 sealed class Flag(
-    internal val key: String,
+    val key: String,
     internal val default: Boolean = false,
     internal val attrs: Map<String, String> = mapOf(),
 )

--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/ActivityBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/ActivityBeanFactory.java
@@ -11,6 +11,7 @@ import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.discover.catalog.DiscoverCatalogActivity;
 import io.airbyte.workers.temporal.scheduling.activities.AutoDisableConnectionActivity;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity;
+import io.airbyte.workers.temporal.scheduling.activities.FeatureFlagFetchActivity;
 import io.airbyte.workers.temporal.scheduling.activities.GenerateInputActivity;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity;
 import io.airbyte.workers.temporal.scheduling.activities.NotifySchemaChangeActivity;
@@ -75,7 +76,8 @@ public class ActivityBeanFactory {
                                                   final StreamResetActivity streamResetActivity,
                                                   final RecordMetricActivity recordMetricActivity,
                                                   final WorkflowConfigActivity workflowConfigActivity,
-                                                  final RouteToSyncTaskQueueActivity routeToSyncTaskQueueActivity) {
+                                                  final RouteToSyncTaskQueueActivity routeToSyncTaskQueueActivity,
+                                                  final FeatureFlagFetchActivity featureFlagFetchActivity) {
     return List.of(generateInputActivity,
         jobCreationAndStatusUpdateActivity,
         configFetchActivity,
@@ -84,7 +86,8 @@ public class ActivityBeanFactory {
         streamResetActivity,
         recordMetricActivity,
         workflowConfigActivity,
-        routeToSyncTaskQueueActivity);
+        routeToSyncTaskQueueActivity,
+        featureFlagFetchActivity);
   }
 
   @Singleton

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.activities;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@ActivityInterface
+public interface FeatureFlagFetchActivity {
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class FeatureFlagFetchInput {
+
+    private UUID connectionId;
+
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class FeatureFlagFetchOutput {
+
+    private Map<String, Boolean> featureFlags;
+
+  }
+
+  /**
+   * Return latest value for feature flags relevant to the ConnectionManagerWorkflow.
+   */
+  @ActivityMethod
+  FeatureFlagFetchOutput getFeatureFlags(FeatureFlagFetchInput input);
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivityImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.activities;
+
+import io.airbyte.api.client.AirbyteApiClient;
+import io.airbyte.api.client.generated.WorkspaceApi;
+import io.airbyte.api.client.model.generated.ConnectionIdRequestBody;
+import io.airbyte.api.client.model.generated.WorkspaceRead;
+import io.airbyte.featureflag.FeatureFlagClient;
+import io.airbyte.featureflag.FieldSelectionEnabled;
+import io.airbyte.featureflag.Flag;
+import io.airbyte.featureflag.Workspace;
+import jakarta.inject.Singleton;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+public class FeatureFlagFetchActivityImpl implements FeatureFlagFetchActivity {
+
+  private final WorkspaceApi workspaceApi;
+  private final FeatureFlagClient featureFlagClient;
+
+  public FeatureFlagFetchActivityImpl(WorkspaceApi workspaceApi,
+                                      FeatureFlagClient featureFlagClient) {
+    this.workspaceApi = workspaceApi;
+    this.featureFlagClient = featureFlagClient;
+  }
+
+  public UUID getWorkspaceId(final UUID connectionId) {
+    final WorkspaceRead workspace = AirbyteApiClient.retryWithJitter(
+        () -> workspaceApi.getWorkspaceByConnectionId(new ConnectionIdRequestBody().connectionId(connectionId)),
+        "get workspace");
+
+    return workspace.getWorkspaceId();
+  }
+
+  @Override
+  public FeatureFlagFetchOutput getFeatureFlags(final FeatureFlagFetchInput input) {
+    final UUID workspaceId = getWorkspaceId(input.getConnectionId());
+
+    // TODO: remove this feature flag from here - not really needed by consumers but in here to get this
+    // activity up and running
+    final List<Flag> workspaceFlags = List.of(FieldSelectionEnabled.INSTANCE);
+    final Map<String, Boolean> featureFlags = new HashMap<>();
+    for (Flag flag : workspaceFlags) {
+      featureFlags.put(flag.getKey(), featureFlagClient.enabled(flag, new Workspace(workspaceId)));
+    }
+
+    return new FeatureFlagFetchOutput(featureFlags);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.activities;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.api.client.generated.WorkspaceApi;
+import io.airbyte.api.client.invoker.generated.ApiException;
+import io.airbyte.api.client.model.generated.ConnectionIdRequestBody;
+import io.airbyte.api.client.model.generated.WorkspaceRead;
+import io.airbyte.featureflag.FeatureFlagClient;
+import io.airbyte.featureflag.FieldSelectionEnabled;
+import io.airbyte.featureflag.TestClient;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FeatureFlagFetchActivityTest {
+
+  final static UUID CONNECTION_ID = UUID.randomUUID();
+  final static UUID WORKSPACE_ID = UUID.randomUUID();
+
+  FeatureFlagFetchActivity featureFlagFetchActivity;
+  FeatureFlagClient featureFlagClient;
+
+  @BeforeEach
+  void setUp() throws ApiException {
+    final WorkspaceApi workspaceApi = mock(WorkspaceApi.class);
+
+    featureFlagClient = new TestClient(Map.of(FieldSelectionEnabled.INSTANCE.getKey(), true));
+    featureFlagFetchActivity = new FeatureFlagFetchActivityImpl(workspaceApi, featureFlagClient);
+
+    when(workspaceApi.getWorkspaceByConnectionId(new ConnectionIdRequestBody().connectionId(CONNECTION_ID)))
+        .thenReturn(new WorkspaceRead().workspaceId(WORKSPACE_ID));
+  }
+
+  @Test
+  void testGetFeatureFlags() {
+    final FeatureFlagFetchActivity.FeatureFlagFetchInput input = new FeatureFlagFetchActivity.FeatureFlagFetchInput(CONNECTION_ID);
+
+    final FeatureFlagFetchActivity.FeatureFlagFetchOutput output = featureFlagFetchActivity.getFeatureFlags(input);
+    Assertions.assertEquals(output.getFeatureFlags(), Map.of(FieldSelectionEnabled.INSTANCE.getKey(), true));
+
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/FeatureFlagFetchActivityTest.java
@@ -14,6 +14,7 @@ import io.airbyte.api.client.model.generated.WorkspaceRead;
 import io.airbyte.featureflag.FeatureFlagClient;
 import io.airbyte.featureflag.FieldSelectionEnabled;
 import io.airbyte.featureflag.TestClient;
+import io.airbyte.featureflag.Workspace;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -32,7 +33,9 @@ class FeatureFlagFetchActivityTest {
   void setUp() throws ApiException {
     final WorkspaceApi workspaceApi = mock(WorkspaceApi.class);
 
-    featureFlagClient = new TestClient(Map.of(FieldSelectionEnabled.INSTANCE.getKey(), true));
+    featureFlagClient = mock(TestClient.class);
+    when(featureFlagClient.enabled(FieldSelectionEnabled.INSTANCE, new Workspace(WORKSPACE_ID))).thenReturn(true);
+
     featureFlagFetchActivity = new FeatureFlagFetchActivityImpl(workspaceApi, featureFlagClient);
 
     when(workspaceApi.getWorkspaceByConnectionId(new ConnectionIdRequestBody().connectionId(CONNECTION_ID)))


### PR DESCRIPTION
## What

Migrated from https://github.com/airbytehq/airbyte/pull/22960

In order to be able to use feature flags within the ConnectionManagerWorkflow, we need to introduce a new activity that fetches the feature flags. This is because we can't directly use the feature flag client in the workflow due to the deterministic constraints of temporal workflows.

This will be used to add a feature flag for https://github.com/airbytehq/airbyte/pull/21899

## How

- Add a new FeatureFlagFetchActivity that runs as the first activity in the ConnectionManagerWorkflow
- Set up the activity to fetch some feature flags. Right now this is looking up an unrelated feature flag, but it used to set up the plumbing to be able to fetch an actually useful flag.
- Update tests
