### PR TITLE
Rename AttemptFailureX -> FailureX API objects for reuse in non-attempt based jobs

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4145,19 +4145,19 @@ components:
         failures:
           type: array
           items:
-            $ref: "#/components/schemas/AttemptFailureReason"
+            $ref: "#/components/schemas/FailureReason"
         partialSuccess:
           description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. If not set, the number of committed records is unknown.
           type: boolean
-    AttemptFailureReason:
+    FailureReason:
       type: object
       required:
         - timestamp
       properties:
         failureOrigin:
-          $ref: "#/components/schemas/AttemptFailureOrigin"
+          $ref: "#/components/schemas/FailureOrigin"
         failureType:
-          $ref: "#/components/schemas/AttemptFailureType"
+          $ref: "#/components/schemas/FailureType"
         externalMessage:
           type: string
         internalMessage:
@@ -4170,7 +4170,7 @@ components:
         timestamp:
           type: integer
           format: int64
-    AttemptFailureOrigin:
+    FailureOrigin:
       description: Indicates where the error originated. If not set, the origin of error is not well known.
       type: string
       enum:
@@ -4182,7 +4182,7 @@ components:
         - dbt
         - airbyte_platform
         - unknown
-    AttemptFailureType:
+    FailureType:
       description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
       type: string
       enum:

--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/converters/JobConverter.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/converters/JobConverter.java
@@ -4,10 +4,7 @@
 
 package io.airbyte.commons.server.converters;
 
-import io.airbyte.api.model.generated.AttemptFailureOrigin;
-import io.airbyte.api.model.generated.AttemptFailureReason;
 import io.airbyte.api.model.generated.AttemptFailureSummary;
-import io.airbyte.api.model.generated.AttemptFailureType;
 import io.airbyte.api.model.generated.AttemptInfoRead;
 import io.airbyte.api.model.generated.AttemptNormalizationStatusRead;
 import io.airbyte.api.model.generated.AttemptRead;
@@ -15,6 +12,9 @@ import io.airbyte.api.model.generated.AttemptStats;
 import io.airbyte.api.model.generated.AttemptStatus;
 import io.airbyte.api.model.generated.AttemptStreamStats;
 import io.airbyte.api.model.generated.DestinationDefinitionRead;
+import io.airbyte.api.model.generated.FailureOrigin;
+import io.airbyte.api.model.generated.FailureReason;
+import io.airbyte.api.model.generated.FailureType;
 import io.airbyte.api.model.generated.JobConfigType;
 import io.airbyte.api.model.generated.JobDebugRead;
 import io.airbyte.api.model.generated.JobInfoLightRead;
@@ -211,9 +211,9 @@ public class JobConverter {
     }
 
     return new AttemptFailureSummary()
-        .failures(failureSummary.getFailures().stream().map(failure -> new AttemptFailureReason()
-            .failureOrigin(Enums.convertTo(failure.getFailureOrigin(), AttemptFailureOrigin.class))
-            .failureType(Enums.convertTo(failure.getFailureType(), AttemptFailureType.class))
+        .failures(failureSummary.getFailures().stream().map(failure -> new FailureReason()
+            .failureOrigin(Enums.convertTo(failure.getFailureOrigin(), FailureOrigin.class))
+            .failureType(Enums.convertTo(failure.getFailureType(), FailureType.class))
             .externalMessage(failure.getExternalMessage())
             .internalMessage(failure.getInternalMessage())
             .stacktrace(failure.getStacktrace())

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/converters/JobConverterTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/converters/JobConverterTest.java
@@ -11,10 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
-import io.airbyte.api.model.generated.AttemptFailureOrigin;
-import io.airbyte.api.model.generated.AttemptFailureReason;
 import io.airbyte.api.model.generated.AttemptFailureSummary;
-import io.airbyte.api.model.generated.AttemptFailureType;
 import io.airbyte.api.model.generated.AttemptInfoRead;
 import io.airbyte.api.model.generated.AttemptRead;
 import io.airbyte.api.model.generated.AttemptStats;
@@ -144,9 +141,9 @@ class JobConverterTest {
                   .createdAt(CREATED_AT)
                   .endedAt(CREATED_AT)
                   .failureSummary(new AttemptFailureSummary()
-                      .failures(Lists.newArrayList(new AttemptFailureReason()
-                          .failureOrigin(AttemptFailureOrigin.SOURCE)
-                          .failureType(AttemptFailureType.SYSTEM_ERROR)
+                      .failures(Lists.newArrayList(new io.airbyte.api.model.generated.AttemptFailureReason()
+                          .failureOrigin(io.airbyte.api.model.generated.AttemptFailureOrigin.SOURCE)
+                          .failureType(io.airbyte.api.model.generated.AttemptFailureType.SYSTEM_ERROR)
                           .externalMessage(FAILURE_EXTERNAL_MESSAGE)
                           .stacktrace(FAILURE_STACKTRACE)
                           .timestamp(FAILURE_TIMESTAMP)))

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/converters/JobConverterTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/converters/JobConverterTest.java
@@ -141,9 +141,9 @@ class JobConverterTest {
                   .createdAt(CREATED_AT)
                   .endedAt(CREATED_AT)
                   .failureSummary(new AttemptFailureSummary()
-                      .failures(Lists.newArrayList(new io.airbyte.api.model.generated.AttemptFailureReason()
-                          .failureOrigin(io.airbyte.api.model.generated.AttemptFailureOrigin.SOURCE)
-                          .failureType(io.airbyte.api.model.generated.AttemptFailureType.SYSTEM_ERROR)
+                      .failures(Lists.newArrayList(new io.airbyte.api.model.generated.FailureReason()
+                          .failureOrigin(io.airbyte.api.model.generated.FailureOrigin.SOURCE)
+                          .failureType(io.airbyte.api.model.generated.FailureType.SYSTEM_ERROR)
                           .externalMessage(FAILURE_EXTERNAL_MESSAGE)
                           .stacktrace(FAILURE_STACKTRACE)
                           .timestamp(FAILURE_TIMESTAMP)))
@@ -235,7 +235,7 @@ class JobConverterTest {
     assertTrue(Enums.isCompatible(JobConfig.ConfigType.class, JobConfigType.class));
     assertTrue(Enums.isCompatible(JobStatus.class, io.airbyte.api.model.generated.JobStatus.class));
     assertTrue(Enums.isCompatible(AttemptStatus.class, io.airbyte.api.model.generated.AttemptStatus.class));
-    assertTrue(Enums.isCompatible(FailureReason.FailureOrigin.class, io.airbyte.api.model.generated.AttemptFailureOrigin.class));
+    assertTrue(Enums.isCompatible(FailureReason.FailureOrigin.class, io.airbyte.api.model.generated.FailureOrigin.class));
   }
 
   // this test intentionally only looks at the reset config as the rest is the same here.

--- a/airbyte-webapp/src/components/JobItem/utils.ts
+++ b/airbyte-webapp/src/components/JobItem/utils.ts
@@ -1,19 +1,12 @@
-import {
-  AttemptFailureReason,
-  AttemptFailureType,
-  AttemptRead,
-  JobStatus,
-  SynchronousJobRead,
-} from "core/request/AirbyteClient";
+import { FailureReason, FailureType, AttemptRead, JobStatus, SynchronousJobRead } from "core/request/AirbyteClient";
 
 import { JobsWithJobs } from "./types";
 
-export const getFailureFromAttempt = (attempt: AttemptRead): AttemptFailureReason | undefined =>
+export const getFailureFromAttempt = (attempt: AttemptRead): FailureReason | undefined =>
   attempt.failureSummary?.failures[0];
 
 export const isCancelledAttempt = (attempt: AttemptRead): boolean =>
-  attempt.failureSummary?.failures.some(({ failureType }) => failureType === AttemptFailureType.manual_cancellation) ??
-  false;
+  attempt.failureSummary?.failures.some(({ failureType }) => failureType === FailureType.manual_cancellation) ?? false;
 
 export const didJobSucceed = (job: SynchronousJobRead | JobsWithJobs): boolean =>
   "succeeded" in job ? job.succeeded : getJobStatus(job) !== "failed";

--- a/airbyte-webapp/src/components/JobItem/utils.ts
+++ b/airbyte-webapp/src/components/JobItem/utils.ts
@@ -1,4 +1,4 @@
-import { FailureReason, FailureType, AttemptRead, JobStatus, SynchronousJobRead } from "core/request/AirbyteClient";
+import { AttemptRead, FailureReason, FailureType, JobStatus, SynchronousJobRead } from "core/request/AirbyteClient";
 
 import { JobsWithJobs } from "./types";
 


### PR DESCRIPTION
## What
* close https://github.com/airbytehq/airbyte/issues/23280
* Pre-emptively update naming before starting to [return failure reasons in api response for synchronous jobs](https://github.com/airbytehq/airbyte/issues/18514), in order to avoid confusion around these jobs not being attempt-based

## Recommended reading order
1. `airbyte-api/src/main/openapi/config.yaml`
2. Resulting changes in other files, which put the failure information into the API response and read information from the API response

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
None