### PR TITLE
🪟 🐛 Ensure source-defined PK and cursor fields are selected when switching sync modes

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.tsx
@@ -21,6 +21,7 @@ import { naturalComparatorBy } from "utils/objects";
 import styles from "./CatalogSection.module.scss";
 import { CatalogTreeTableRow } from "./next/CatalogTreeTableRow";
 import { StreamDetailsPanel } from "./next/StreamDetailsPanel/StreamDetailsPanel";
+import { SyncModeValue } from "./next/SyncModeSelect";
 import {
   updatePrimaryKey,
   toggleFieldInPrimaryKey,
@@ -28,6 +29,7 @@ import {
   updateFieldSelected,
   toggleAllFieldsSelected,
 } from "./streamConfigHelpers/streamConfigHelpers";
+import { updateStreamSyncMode } from "./streamConfigHelpers/updateStreamSyncMode";
 import { StreamFieldTable } from "./StreamFieldTable";
 import { StreamHeader } from "./StreamHeader";
 import { flatten, getPathType } from "./utils";
@@ -77,8 +79,16 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
   );
 
   const onSelectSyncMode = useCallback(
-    (data: DropDownOptionDataItem) => updateStreamWithConfig(data.value),
-    [updateStreamWithConfig]
+    (data: DropDownOptionDataItem) => {
+      if (!streamNode.config || !streamNode.stream) {
+        return;
+      }
+      // todo: Remove once new stream table design is released. The old dropdown types data.value as any, hence the cast here.
+      const syncModes = data.value as SyncModeValue;
+      const updatedConfig = updateStreamSyncMode(streamNode.stream, streamNode.config, syncModes);
+      updateStreamWithConfig(updatedConfig);
+    },
+    [streamNode, updateStreamWithConfig]
   );
 
   const onSelectStream = useCallback(

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/SyncModeSelect.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/SyncModeSelect.tsx
@@ -9,7 +9,7 @@ import { DestinationSyncMode, SyncMode } from "core/request/AirbyteClient";
 
 import styles from "./SyncModeSelect.module.scss";
 
-interface SyncModeValue {
+export interface SyncModeValue {
   syncMode: SyncMode;
   destinationSyncMode: DestinationSyncMode;
 }

--- a/airbyte-webapp/src/components/connection/CatalogTree/streamConfigHelpers/updateStreamSyncMode.test.ts
+++ b/airbyte-webapp/src/components/connection/CatalogTree/streamConfigHelpers/updateStreamSyncMode.test.ts
@@ -1,0 +1,98 @@
+import { mockAirbyteStream } from "test-utils/mock-data/mockAirbyteStream";
+import { mockStreamConfiguration } from "test-utils/mock-data/mockAirbyteStreamConfiguration";
+
+import { updateStreamSyncMode } from "./updateStreamSyncMode";
+import { SyncModeValue } from "../next/SyncModeSelect";
+
+describe(`${updateStreamSyncMode.name}`, () => {
+  it("updates the sync modes", () => {
+    const syncModes: SyncModeValue = {
+      syncMode: "full_refresh",
+      destinationSyncMode: "overwrite",
+    };
+    expect(updateStreamSyncMode(mockAirbyteStream, mockStreamConfiguration, syncModes)).toEqual(
+      expect.objectContaining({ ...syncModes })
+    );
+  });
+
+  describe("when fieldSelection is enabled", () => {
+    const PK_PART_ONE = ["pk_part_one"];
+    const PK_PART_TWO = ["pk_part_two"];
+    const DEFAULT_CURSOR_FIELD_PATH = ["default_cursor"];
+    const DEFAULT_PRIMARY_KEY = [PK_PART_ONE, PK_PART_TWO];
+    const UNRELATED_FIELD_PATH = ["unrelated_field_path"];
+
+    it("does not add default pk or cursor for irrelevant sync modes", () => {
+      const syncModes: SyncModeValue = {
+        syncMode: "full_refresh",
+        destinationSyncMode: "overwrite",
+      };
+      const updatedConfig = updateStreamSyncMode(
+        {
+          ...mockAirbyteStream,
+          sourceDefinedCursor: true,
+          defaultCursorField: DEFAULT_CURSOR_FIELD_PATH,
+          sourceDefinedPrimaryKey: DEFAULT_PRIMARY_KEY,
+        },
+        mockStreamConfiguration,
+        syncModes
+      );
+
+      expect(updatedConfig).toEqual(
+        expect.objectContaining({
+          fieldSelectionEnabled: false,
+          selectedFields: [],
+          ...syncModes,
+        })
+      );
+    });
+
+    it("automatically selects the default cursor", () => {
+      const syncModes: SyncModeValue = {
+        syncMode: "incremental",
+        destinationSyncMode: "append",
+      };
+
+      const updatedConfig = updateStreamSyncMode(
+        { ...mockAirbyteStream, sourceDefinedCursor: true, defaultCursorField: DEFAULT_CURSOR_FIELD_PATH },
+        {
+          ...mockStreamConfiguration,
+          fieldSelectionEnabled: true,
+          selectedFields: [{ fieldPath: UNRELATED_FIELD_PATH }],
+        },
+        syncModes
+      );
+
+      expect(updatedConfig).toEqual(
+        expect.objectContaining({
+          ...syncModes,
+          selectedFields: [{ fieldPath: UNRELATED_FIELD_PATH }, { fieldPath: DEFAULT_CURSOR_FIELD_PATH }],
+        })
+      );
+    });
+
+    it("automatically selects the composite primary key fields", () => {
+      const syncModes: SyncModeValue = {
+        syncMode: "incremental",
+        destinationSyncMode: "append_dedup",
+      };
+
+      const updatedConfig = updateStreamSyncMode(
+        { ...mockAirbyteStream, sourceDefinedPrimaryKey: DEFAULT_PRIMARY_KEY },
+        {
+          ...mockStreamConfiguration,
+          fieldSelectionEnabled: true,
+          selectedFields: [{ fieldPath: UNRELATED_FIELD_PATH }],
+        },
+        syncModes
+      );
+
+      expect(updatedConfig).toEqual(
+        expect.objectContaining({
+          ...syncModes,
+          selectedFields: [{ fieldPath: UNRELATED_FIELD_PATH }, { fieldPath: PK_PART_ONE }, { fieldPath: PK_PART_TWO }],
+        })
+      );
+    });
+  });
+});

--- a/airbyte-webapp/src/components/connection/CatalogTree/streamConfigHelpers/updateStreamSyncMode.ts
+++ b/airbyte-webapp/src/components/connection/CatalogTree/streamConfigHelpers/updateStreamSyncMode.ts
@@ -1,0 +1,65 @@
+import {
+  AirbyteStream,
+  AirbyteStreamConfiguration,
+  DestinationSyncMode,
+  SelectedFieldInfo,
+  SyncMode,
+} from "core/request/AirbyteClient";
+
+import { mergeFieldPathArrays } from "./streamConfigHelpers";
+
+export function updateStreamSyncMode(
+  stream: AirbyteStream,
+  config: AirbyteStreamConfiguration,
+  syncModes: { syncMode: SyncMode; destinationSyncMode: DestinationSyncMode }
+): AirbyteStreamConfiguration {
+  const { syncMode, destinationSyncMode } = syncModes;
+
+  // If field selection was enabled, we need to ensure that any source-defined primary key or cursor is selected automatically
+  if (config?.fieldSelectionEnabled) {
+    const previouslySelectedFields = config?.selectedFields || [];
+    const requiredSelectedFields: SelectedFieldInfo[] = [];
+
+    // If the sync mode is incremental, we need to ensure the cursor is selected
+    if (syncMode === "incremental") {
+      if (stream.sourceDefinedCursor && stream.defaultCursorField?.length) {
+        requiredSelectedFields.push({ fieldPath: stream.defaultCursorField });
+      }
+      if (config.cursorField?.length) {
+        requiredSelectedFields.push({ fieldPath: config.cursorField });
+      }
+    }
+
+    // If the destination sync mode is append_dedup, we need to ensure that each piece of the composite primary key is selected
+    if (destinationSyncMode === "append_dedup" && stream.sourceDefinedPrimaryKey) {
+      if (stream.sourceDefinedPrimaryKey?.length) {
+        requiredSelectedFields.push(
+          ...stream.sourceDefinedPrimaryKey.map((path) => ({
+            fieldPath: path,
+          }))
+        );
+      }
+      if (config.primaryKey) {
+        requiredSelectedFields.push(
+          ...config.primaryKey.map((path) => ({
+            fieldPath: path,
+          }))
+        );
+      }
+    }
+
+    // Deduplicate the selected fields array, since the same field could have been added twice (e.g. as cursor and pk)
+    const selectedFields = mergeFieldPathArrays(previouslySelectedFields, requiredSelectedFields);
+
+    return {
+      ...config,
+      selectedFields,
+      ...syncModes,
+    };
+  }
+
+  return {
+    ...config,
+    ...syncModes,
+  };
+}

--- a/airbyte-webapp/src/test-utils/mock-data/mockAirbyteStream.ts
+++ b/airbyte-webapp/src/test-utils/mock-data/mockAirbyteStream.ts
@@ -1,0 +1,5 @@
+import { AirbyteStream } from "core/request/AirbyteClient";
+
+export const mockAirbyteStream: AirbyteStream = {
+  name: "Mock stream",
+};


### PR DESCRIPTION
Migration of https://github.com/airbytehq/airbyte/pull/22559

## What
Closes https://github.com/airbytehq/airbyte/issues/21817

Ensures that source-defined cursors and primary keys are automatically selected when changing sync modes. Users may deselect a primary key or cursor when the sync mode is `full_refresh` or the destination sync mode is `overwrite`. If they switch back to an `incremental` or `append_dedup` sync mode, we need to ensure that these source-defined fields are automatically selected.

This is a frontend change only and is easily revertible.