### PR TITLE
Disable connection edit tabs during schema refresh

### DIFF
--- a/airbyte-webapp/src/components/ui/StepsMenu/Step.tsx
+++ b/airbyte-webapp/src/components/ui/StepsMenu/Step.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components";
 
 interface StepProps {
@@ -9,12 +9,14 @@ interface StepProps {
   isActive?: boolean;
   icon?: React.ReactNode;
   num: number;
+  disabled?: boolean;
 }
 
 const StepView = styled.div<{
   isActive?: boolean;
   lightMode?: boolean;
   nonClickable?: boolean;
+  hidden?: boolean;
 }>`
   width: ${({ lightMode }) => (lightMode ? "auto" : "212px")};
   min-width: ${({ lightMode }) => (lightMode ? "100px" : "auto")};
@@ -34,6 +36,8 @@ const StepView = styled.div<{
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  pointer-events: ${({ nonClickable }) => (nonClickable ? "none" : "initial")};
+  opacity: ${({ nonClickable }) => (nonClickable ? "0.5" : "1")};
 `;
 
 const Num = styled.div<{ isActive?: boolean }>`
@@ -51,17 +55,13 @@ const Num = styled.div<{ isActive?: boolean }>`
   box-shadow: 0 1px 2px 0 ${({ theme }) => theme.shadowColor};
 `;
 
-export const Step: React.FC<StepProps> = ({ name, id, isActive, onClick, num, lightMode, icon }) => {
-  const onItemClickItem = () => {
-    if (onClick) {
-      onClick(id);
-    }
-  };
+export const Step: React.FC<StepProps> = ({ name, id, isActive, onClick, num, lightMode, icon, disabled }) => {
+  const onItemClickItem = useCallback(() => onClick?.(id), [id, onClick]);
 
   return (
     <StepView
       data-id={`${id.toLowerCase()}-step`}
-      nonClickable={!onClick}
+      nonClickable={!onClick || disabled}
       onClick={onItemClickItem}
       isActive={isActive}
       lightMode={lightMode}

--- a/airbyte-webapp/src/components/ui/StepsMenu/StepsMenu.tsx
+++ b/airbyte-webapp/src/components/ui/StepsMenu/StepsMenu.tsx
@@ -15,6 +15,7 @@ interface StepMenuProps {
   data: StepMenuItem[];
   activeStep?: string;
   onSelect?: (id: string) => void;
+  disabled?: boolean;
 }
 
 const Content = styled.div`
@@ -24,7 +25,7 @@ const Content = styled.div`
   font-family: ${({ theme }) => theme.regularFont};
 `;
 
-export const StepsMenu: React.FC<StepMenuProps> = ({ data, onSelect, activeStep, lightMode }) => {
+export const StepsMenu: React.FC<StepMenuProps> = ({ data, onSelect, activeStep, lightMode, disabled }) => {
   return (
     <Content>
       {data.map((item, key) => (
@@ -37,6 +38,7 @@ export const StepsMenu: React.FC<StepMenuProps> = ({ data, onSelect, activeStep,
           id={item.id}
           onClick={item.onSelect || onSelect}
           isActive={activeStep === item.id}
+          disabled={disabled}
         />
       ))}
     </Content>

--- a/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx
@@ -64,7 +64,7 @@ const useConnectionEdit = ({ connectionId }: ConnectionEditProps): ConnectionEdi
         text: formatMessage({ id: "connection.updateSchema.noDiff" }),
       });
     }
-  }, [connectionId]);
+  });
 
   const discardRefreshedSchema = useCallback(() => {
     setConnection((connection) => ({

--- a/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
+++ b/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
@@ -27,7 +27,7 @@ export const ConnectionPageTitle: React.FC = () => {
   const navigate = useNavigate();
   const currentStep = params["*"] || ConnectionRoutePaths.Status;
 
-  const { connection } = useConnectionEditService();
+  const { connection, schemaRefreshing } = useConnectionEditService();
 
   const steps = useMemo(() => {
     const steps = [
@@ -85,7 +85,7 @@ export const ConnectionPageTitle: React.FC = () => {
           {fcpEnabled && <InlineEnrollmentCallout />}
         </FlexContainer>
       </div>
-      <StepsMenu lightMode data={steps} onSelect={onSelectStep} activeStep={currentStep} />
+      <StepsMenu lightMode data={steps} onSelect={onSelectStep} activeStep={currentStep} disabled={schemaRefreshing} />
     </div>
   );
 };


### PR DESCRIPTION
Migration of https://github.com/airbytehq/airbyte/pull/22844

## What
Resolves https://github.com/airbytehq/airbyte/issues/22628
Disables the tabs while the schema is refreshing. _Does not hide them_

## How
Add disabled functionality to StepsMenu and Steps components