### PR TITLE
Normalization: update to strict_comparison2

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -74,7 +74,7 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
 
   @Override
   public String strictComparisonNormalizationTag() {
-    return getEnvOrDefault(STRICT_COMPARISON_NORMALIZATION_TAG, "strict_comparison", (arg) -> arg);
+    return getEnvOrDefault(STRICT_COMPARISON_NORMALIZATION_TAG, "strict_comparison2", (arg) -> arg);
   }
 
   // TODO: refactor in order to use the same method than the ones in EnvConfigs.java

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -1167,7 +1167,7 @@ public class EnvConfigs implements Configs {
 
   @Override
   public String getStrictComparisonNormalizationTag() {
-    return getEnvOrDefault(STRICT_COMPARISON_NORMALIZATION_TAG, "strict_comparison");
+    return getEnvOrDefault(STRICT_COMPARISON_NORMALIZATION_TAG, "strict_comparison2");
   }
 
   @Override

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/NormalizationActivityImplTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/NormalizationActivityImplTest.java
@@ -23,17 +23,17 @@ class NormalizationActivityImplTest {
     Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.4.1")));
     Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("dev")));
     Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("protocolv1")));
-    Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("strict_comparison")));
+    Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("strict_comparison2")));
   }
 
   @Test
   void checkNormalizationTagReplacement() {
     final FeatureFlags featureFlags = mock(FeatureFlags.class);
-    when(featureFlags.strictComparisonNormalizationTag()).thenReturn("strict_comparison");
+    when(featureFlags.strictComparisonNormalizationTag()).thenReturn("strict_comparison2");
 
     final IntegrationLauncherConfig config = withNormalizationVersion("0.2.25");
-    NormalizationActivityImpl.replaceNormalizationImageTag(config, "strict_comparison");
-    assertEquals("normalization:strict_comparison", config.getNormalizationDockerImage());
+    NormalizationActivityImpl.replaceNormalizationImageTag(config, "strict_comparison2");
+    assertEquals("normalization:strict_comparison2", config.getNormalizationDockerImage());
   }
 
   private IntegrationLauncherConfig withNormalizationVersion(final String version) {

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -72,6 +72,6 @@ data:
   WORKER_STATE_STORAGE_TYPE:  {{ .Values.global.state.storage.type | quote }}
   SHOULD_RUN_NOTIFY_WORKFLOWS: "false"
   MAX_NOTIFY_WORKERS: {{ .Values.worker.maxNotifyWorkers | default "5" | quote }}
-  STRICT_COMPARISON_NORMALIZATION_TAG: {{ .Values.worker.strictComparisonNormalizationTag | default "strict_comparison" | quote }}
+  STRICT_COMPARISON_NORMALIZATION_TAG: {{ .Values.worker.strictComparisonNormalizationTag | default "strict_comparison2" | quote }}
   STRICT_COMPARISON_NORMALIZATION_WORKSPACES: {{ .Values.worker.strictComparisonNormalizationWorkspaces | default "" | quote }}
 {{- end }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -826,7 +826,7 @@ worker:
 
   maxNotifyWorkers: 5
 
-  strictComparisonNormalizationTag: "strict_comparison"
+  strictComparisonNormalizationTag: "strict_comparison2"
   strictComparisonNormalizationWorkspaces: ""
 
 ## @section Metrics parameters


### PR DESCRIPTION
This is a new version of strict_comparison normalization with latest changes from master. Bump the default env var values to the new tag.

Question for reviewer: I don't need to replicate these changes into the connectors repo, right? E.g. https://github.com/airbytehq/airbyte/blob/c55a81bbcb9ca0999949fb0ed0a20bfbcc425525/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java#L77