### PR TITLE
:bug: fix: bump version entries in cfg to not have non-existant paths

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -46,18 +46,6 @@ replace = "version": "{new_version}"
 
 [bumpversion:file:charts/airbyte/README.md]
 
-[bumpversion:file:docs/operator-guides/upgrading-airbyte.md]
-
-[bumpversion:file:octavia-cli/Dockerfile]
-
-[bumpversion:file:octavia-cli/README.md]
-
-[bumpversion:file:octavia-cli/install.sh]
-
-[bumpversion:file:octavia-cli/setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:airbyte-connector-builder-server/Dockerfile]
 
 [bumpversion:file:airbyte-connector-builder-server/setup.py]


### PR DESCRIPTION
:bug: fix: bump version entries in cfg to not have non-existant paths

https://github.com/airbytehq/airbyte/actions/runs/4239281966/jobs/7367197306

```
Run ./tools/bin/bump_version.sh
++ grep -w VERSION .env
++ cut -d= -f2
+ PREV_VERSION=0.40.32
++ git rev-parse HEAD
+ GIT_REVISION=37be4c6fcc84d6212847b56bcfe305799c9607dd
+ pip install bumpversion
Collecting bumpversion
  Downloading bumpversion-0.6.0-py2.py3-none-any.whl (8.4 kB)
Collecting bump2version
  Downloading bump2version-1.0.1-py2.py3-none-any.whl (22 kB)
Installing collected packages: bump2version, bumpversion
Successfully installed bump2version-1.0.1 bumpversion-0.6.0
+ bumpversion patch
Traceback (most recent call last):
  File "/actions-runner/_work/_tool/Python/3.9.16/x64/bin/bumpversion", line 8, in <module>
    sys.exit(main())
  File "/actions-runner/_work/_tool/Python/3.9.16/x64/lib/python3.9/site-packages/bumpversion/cli.py", line 124, in main
    _check_files_contain_version(files, current_version, context)
  File "/actions-runner/_work/_tool/Python/3.9.16/x64/lib/python3.9/site-packages/bumpversion/cli.py", line 618, in _check_files_contain_version
    f.should_contain_version(current_version, context)
  File "/actions-runner/_work/_tool/Python/3.9.16/x64/lib/python3.9/site-packages/bumpversion/utils.py", line 51, in should_contain_version
    if self.contains(search_expression):
  File "/actions-runner/_work/_tool/Python/3.9.16/x64/lib/python3.9/site-packages/bumpversion/utils.py", line 78, in contains
    with open(self.path, "rt", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'docs/operator-guides/upgrading-airbyte.md'
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/airbytehq/airbyte-platform/pull/106).
* __->__ #106
