### PR TITLE
Connector Builder UI: hide next page icon if last response page is selected

### DIFF
--- a/airbyte-webapp/src/components/ui/Paginator/Paginator.module.scss
+++ b/airbyte-webapp/src/components/ui/Paginator/Paginator.module.scss
@@ -29,7 +29,11 @@ $containerHeight: 23px;
     user-select: none;
   }
 
-  &:hover:not(.active) {
+  &:hover:is(.disabled) {
+    cursor: default;
+  }
+
+  &:hover:not(.active, .disabled) {
     background-color: colors.$grey-100;
   }
 }
@@ -48,6 +52,10 @@ $containerHeight: 23px;
   justify-self: flex-end;
   margin-right: 0;
   margin-left: auto;
+}
+
+.disabled {
+  color: colors.$grey;
 }
 
 .active {

--- a/airbyte-webapp/src/components/ui/Paginator/Paginator.tsx
+++ b/airbyte-webapp/src/components/ui/Paginator/Paginator.tsx
@@ -38,6 +38,7 @@ export const Paginator: React.FC<PaginatorProps> = ({ className, numPages, onPag
     pageClassName={classNames(styles.button, styles.page)}
     breakClassName={classNames(styles.button, styles.break)}
     activeClassName={styles.active}
+    disabledClassName={styles.disabled}
     previousClassName={classNames(styles.button, styles.previous)}
     nextClassName={classNames(styles.button, styles.next)}
   />


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-platform-internal/issues/4636

Demo: https://www.loom.com/share/7a56ad4a5cb742dda5f8e37b9a7212bf

## How
Adds a CSS class `disabled` which greys out member classes, and modifies the `button` class styling to grey out instances with the `.disabled` class and prevent changing their mouse cursor. Then it uses `react-paginate`'s `[disabledClassName](https://github.com/AdeleD/react-paginate#props)` property to apply the `.disabled` class to the prev/next buttons when the first/last page is selected.

## Can this PR be safely reverted / rolled back?
- [x] YES 💚
- [ ] NO ❌
