### PR TITLE
replace dynamic group name with airbyte

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ allprojects {
     // by default gradle uses directory as the project name. That works very well in a single project environment but
     // projects clobber each other in an environments with subprojects when projects are in directories named identically.
     def sub = rootDir.relativePath(projectDir.parentFile).replace('/', '.')
-    group = "io.${rootProject.name}${sub.isEmpty() ? '' : ".$sub"}"
+    group = "io.airbyte${sub.isEmpty() ? '' : ".$sub"}"
     project.archivesBaseName = "${project.group}-${project.name}"
 
     version = rootProject.ext.version
@@ -214,7 +214,6 @@ allprojects {
 
 // Java projects common configurations
 subprojects { subproj ->
-
 
     configurations {
         runtimeClasspath


### PR DESCRIPTION
## What
- part of airbytehq/airbyte-platform-internal#4475
- replace dynamic group name `group = "io.${rootProject.name}...` with `group = "io.airbyte`...
    - the dynamic group doesn't play nice with the inline oss builds

## Can this PR be safely reverted / rolled back?
- [x] YES 💚
- [ ] NO ❌


