### PR TITLE
ci: add oss-pr-snapshot workflow

### DIFF
--- a/.github/workflows/create-oss-pr-snapshot-in-cloud.yml
+++ b/.github/workflows/create-oss-pr-snapshot-in-cloud.yml
@@ -1,4 +1,4 @@
-name: Create Pull Request Snapshot in Cloud
+name: Create OSS Pull Request Snapshot
 
 on:
   issue_comment:
@@ -6,27 +6,26 @@ on:
 
 jobs:
   check:
-      if: startsWith(github.head_ref, 'main') != true
-      runs-on: ubuntu-18.04
-      outputs:
-        pull_request_branch: ${{ steps.comment-branch.outputs.head_ref }}
-        branch_up_to_date: ${{ steps.branch-up-to-date.outputs.up_to_date }}
-      steps:
-        - uses: xt0rted/pull-request-comment-branch@v1
-          id: comment-branch
-        - uses: actions/checkout@v3
-          with:
-            ref: ${{ steps.comment-branch.outputs.head_ref }}
-            fetch-depth: 0 # needed to have the base branch available for the action below
-        - uses: stefanluptak/check-branch-up-to-date@v1
-          id: branch-up-to-date
-          with:
-            base_branch: 'main'
-            head_branch: ${{ steps.comment-branch.outputs.head_ref }}
+    if: startsWith(github.head_ref, 'main') != true
+    runs-on: ubuntu-latest
+    outputs:
+      pull_request_branch: ${{ steps.comment-branch.outputs.head_ref }}
+      branch_up_to_date: ${{ steps.branch-up-to-date.outputs.up_to_date }}
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          fetch-depth: 0 # needed to have the base branch available for the action below
+      - uses: stefanluptak/check-branch-up-to-date@v1
+        id: branch-up-to-date
+        with:
+          base_branch: 'main'
+          head_branch: ${{ steps.comment-branch.outputs.head_ref }}
 
-  dispatch_command_to_cloud:
+  dispatch_command_to_platform_internal:
     needs: check
-    if: needs.check.outputs.branch_up_to_date == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Create a snapshot of an OSS PR to Cloud
@@ -36,15 +35,14 @@ jobs:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           permission: write
           issue-type: pull-request
-          repository: airbytehq/airbyte-platform-internal
+          repository: airbytehq/airbyte-platform
           dispatch-type: repository
           static-args: |
             repository=${{ github.repository }}
             branch=${{ needs.check.outputs.pull_request_branch }}
-            pr_number=${{ github.event.issue_comment.issue.number }}
+            pr_number=${{ github.event.issue.number }}
           commands: |
-            create-cloud-pr
-
+            create-oss-pr
       - name: Publish comment with error message
         if: steps.slash-command-dispatch.outputs.error-message
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
## What
Adds a new workflow for handling the `/create-oss-pr` slash command.
This command is configured to dispatch to `airbytehq/airbyte-platform-internal`.

## How
*Describe the solution*

## Recommended reading order
- [.github/workflows/create-oss-pr-snapshot-in-cloud.yml](https://github.com/airbytehq/airbyte-platform/compare/main...perangel/oss-to-internal-workflow#diff-467cdb921e3da3e7b4a604495a8bdc47ac192ca9d0a3dbc196a74468942c8713)

## Can this PR be safely reverted / rolled back?
Yes

## 🚨 User Impact 🚨
None
