### PR TITLE
[Migration] [Connector Builder] Return string format to allow for connector read() that return non-object responses

### DIFF
--- a/airbyte-connector-builder-server/connector_builder/generated/models/http_response.py
+++ b/airbyte-connector-builder-server/connector_builder/generated/models/http_response.py
@@ -22,7 +22,7 @@ class HttpResponse(BaseModel):
     """
 
     status: int
-    body: Optional[Dict[str, Any]] = None
+    body: Optional[str] = None
     headers: Optional[Dict[str, Any]] = None
 
 HttpResponse.update_forward_refs()

--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -156,7 +156,7 @@ spec:
             logs=log_messages,
             slices=slices,
             test_read_limit_reached=self._has_reached_limit(slices),
-            inferred_schema=schema_inferrer.get_stream_schema(stream_read_request_body.stream)
+            inferred_schema=schema_inferrer.get_stream_schema(stream_read_request_body.stream),
         )
 
     def _has_reached_limit(self, slices):
@@ -286,7 +286,7 @@ spec:
         raw_response = log_message.message.partition("response:")[2]
         try:
             response = json.loads(raw_response)
-            body = json.loads(response.get("body", "{}"))
+            body = response.get("body", "{}")
             return HttpResponse(status=response.get("status_code"), body=body, headers=response.get("headers"))
         except JSONDecodeError as error:
             self.logger.warning(f"Failed to parse log message into response object with error: {error}")

--- a/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
+++ b/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
@@ -213,7 +213,7 @@ components:
           type: integer
           description: The status of the response
         body:
-          type: object
+          type: string
           description: The body of the HTTP response, if present
         headers:
           type: object

--- a/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/PageDisplay.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/PageDisplay.tsx
@@ -40,7 +40,25 @@ export const PageDisplay: React.FC<PageDisplayProps> = ({ page, className, infer
 
   const formattedRecords = useMemo(() => formatJson(page.records), [page.records]);
   const formattedRequest = useMemo(() => formatJson(page.request), [page.request]);
-  const formattedResponse = useMemo(() => formatJson(page.response), [page.response]);
+  const formattedResponse = useMemo(() => {
+    if (!page.response || !page.response.body) {
+      return "";
+    }
+    let parsedBody: unknown;
+    try {
+      // body is a string containing JSON most of the time, but not always.
+      // Attempt to parse and fall back to the raw string if unsuccessfull.
+      parsedBody = JSON.parse(page.response.body);
+    } catch {
+      parsedBody = page.response.body;
+    }
+
+    const unpackedBodyResponse = {
+      ...page.response,
+      body: parsedBody,
+    };
+    return formatJson(unpackedBodyResponse);
+  }, [page.response]);
   const formattedSchema = useMemo(() => inferredSchema && formatJson(inferredSchema, true), [inferredSchema]);
 
   let defaultTabIndex = 0;


### PR DESCRIPTION
Migrates https://github.com/airbytehq/airbyte/issues/20764 after the platform monorepo split

joe wrote the FE and I wrote the connector builder changes

## What
For APIs with responses that were non-object responses encapsulated in `{ ... }`. The connector builder read() would fail. It is perfectly reasonable for a API to response with an array of elements `[ ... ]` and potentially even string input. This change should allow for both.

## How
The connector builder server no longer parsed response output into a json object because it might not be one. Instead we pass along the string output and let the frontend handle deserializing it back into the appropriate object to display back in the test output window

## Recommended reading order
1. `default_api.py`
2. `PageDisplay.tsx`

## Can this PR be safely reverted / rolled back?

- [x] YES 💚