### PR TITLE
🪟 🐛 Fix docs download

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Copy docs from connectors repository
         run: |
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
+          mkdir -p ./docs
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
           [ -f "./docs/integrations/sources/google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
@@ -289,6 +290,16 @@ jobs:
           org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
+
+      # TODO: Once we pull these from the metadata service, remove this step. Also we can't build the webapp locally
+      #       since docs are not pulled when running gradle locally.
+      - name: Copy docs from connectors repository
+        run: |
+          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
+          mkdir -p ./docs
+          cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
+          cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build Platform Docker Images
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,7 +169,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,7 +169,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 }
+          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 };
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,7 +169,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21; }
+          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,7 +169,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
+          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -162,14 +162,14 @@ jobs:
           org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
-      # TODO: Once we pull these from the metadata service, remove this step
+      # TODO: Once we pull these from the metadata service, remove this step. Also we can't build the webapp locally
+      #       since docs are not pulled when running gradle locally.
       - name: Copy docs from connectors repository
         run: |
-          dir=$PWD
-          cd /tmp
-          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte 
-          cp -R airbyte/docs $dir/docs
-          ls -lah $dir/docs
+          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
+          cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
+          cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
+          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 }
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,7 +169,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 };
+          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build :airbyte-webapp
         uses: Wandalen/wretry.action@master

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 }
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 };
 
       - name: Build Branch
         uses: ./.github/actions/build-branch

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build Branch
         uses: ./.github/actions/build-branch

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Copy docs from connectors repository
         run: |
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
+          mkdir -p ./docs
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
           [ -f "./docs/integrations/sources/google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 };
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build Branch
         uses: ./.github/actions/build-branch

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
+          [ -f "./docs/integrations/sources/NOT_google-ads.md" ] || { ls -Rlha ./docs; echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build Branch
         uses: ./.github/actions/build-branch

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
           cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
           cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
-          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21; }
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error ::Failed to copy docs from airbyte repository"; exit 21; }
 
       - name: Build Branch
         uses: ./.github/actions/build-branch

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -82,14 +82,14 @@ jobs:
         with:
           ref: ${{ github.event.inputs.oss_ref || github.ref }}
 
-      # TODO: Once we pull these from the metadata service, remove this step
+      # TODO: Once we pull these from the metadata service, remove this step. Also we can't build the webapp locally
+      #       since docs are not pulled when running gradle locally.
       - name: Copy docs from connectors repository
         run: |
-          dir=$PWD
-          cd /tmp
-          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte 
-          cp -R airbyte/docs $dir/docs
-          ls -lah $dir/docs
+          git clone --depth 1 https://.:${{ secrets.GITHUB_TOKEN }}@github.com/airbytehq/airbyte /tmp/airbyte_repo
+          cp -R /tmp/airbyte_repo/docs/integrations ./docs/integrations
+          cp -R /tmp/airbyte_repo/docs/.gitbook ./docs/.gitbook
+          [ -f "./docs/integrations/sources/google-ads.md" ] || { echo "::error Failed to copy docs from airbyte repository"; exit 21 }
 
       - name: Build Branch
         uses: ./.github/actions/build-branch


### PR DESCRIPTION
## What

Fixes the doc download script. This currently copied `docs` **into** `./docs` (i.e. created a `./docs/docs` folder) and thus had a wrong nesting layer.

## How

Changing this to only copy the actual 2 folder we need (and also making sure they land in the right pathes). Also validate that a file we know should exist actually exist in the right path, otherwise fail the build.

I validated that the docs are bundled by checking inside the `airbyte/webapp:dev-c42ae05a14` image that has been published by this task, that it contains the docs under `/usr/share/nginx/html/docs`.