### PR TITLE
🪟🐛 Connectors view: Fix max icon width

### DIFF
--- a/airbyte-webapp/src/pages/SettingsPage/pages/ConnectorsPage/components/ConnectorCell.module.scss
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/ConnectorsPage/components/ConnectorCell.module.scss
@@ -1,3 +1,4 @@
 .iconContainer {
   height: 25px;
+  max-width: 25px;
 }


### PR DESCRIPTION
Before:
<img width="327" alt="Screenshot 2023-02-27 at 16 23 49" src="https://user-images.githubusercontent.com/1508364/221605399-315d192a-21da-4f75-aa6a-4c0b2be7ee76.png">

After:
<img width="256" alt="Screenshot 2023-02-27 at 16 23 42" src="https://user-images.githubusercontent.com/1508364/221605392-3393d09d-33c8-4f99-b136-00c1591393c1.png">

Theoretically all icons should have a 1:1 ratio already, but if this isn't the case they should be scaled down accordingly.