### PR TITLE
Helm chart publish trigger fix

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -5,7 +5,7 @@ concurrency:
 on:
   push:
     branches:
-      - "master"
+      - "main"
     paths:
       - "charts/**"
       - "!charts/**/Chart.yaml"


### PR DESCRIPTION
master is now main because we moved repos

this will enable builds to trigger when they hit main
