### PR TITLE
add builder route behind experiment

### DIFF
--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -6,10 +6,12 @@ import { ApiErrorBoundary } from "components/common/ApiErrorBoundary";
 import LoadingPage from "components/LoadingPage";
 
 import { useAnalyticsIdentifyUser, useAnalyticsRegisterValues } from "hooks/services/Analytics/useAnalyticsService";
+import { useExperiment } from "hooks/services/Experiment";
 import { useApiHealthPoll } from "hooks/services/Health";
 import { useBuildUpdateCheck } from "hooks/services/useBuildUpdateCheck";
 import { useQuery } from "hooks/useQuery";
 import { useAuthService } from "packages/cloud/services/auth/AuthService";
+import ConnectorBuilderRoutes from "pages/connectorBuilder/ConnectorBuilderRoutes";
 import { useCurrentWorkspace, WorkspaceServiceProvider } from "services/workspaces/WorkspacesService";
 import { setSegmentAnonymousId, useGetSegmentAnonymousId } from "utils/crossDomainUtils";
 import { CompleteOauthRequest } from "views/CompleteOauthRequest";
@@ -54,6 +56,8 @@ const MainRoutes: React.FC = () => {
   );
   useAnalyticsRegisterValues(analyticsContext);
 
+  const showBuilderNavigationLinks = useExperiment("connectorBuilder.showNavigationLinks", false);
+
   return (
     <ApiErrorBoundary>
       <Routes>
@@ -76,6 +80,9 @@ const MainRoutes: React.FC = () => {
         <Route path={`${RoutePaths.Connections}/*`} element={<ConnectionsRoutes />} />
         <Route path={`${RoutePaths.Settings}/*`} element={<CloudSettingsPage />} />
         <Route path={CloudRoutes.Credits} element={<CreditsPage />} />
+        {showBuilderNavigationLinks && (
+          <Route path={`${RoutePaths.ConnectorBuilder}/*`} element={<ConnectorBuilderRoutes />} />
+        )}
         <Route path="*" element={<Navigate to={RoutePaths.Connections} replace />} />
       </Routes>
     </ApiErrorBoundary>


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/21284

Enables the /connector-builder route on cloud behind a feature flag, reusing the `connectorBuilder.showNavigationLinks` experiment that controls if connector builder navigation links are shown.

This is being done in preparation for adding the connector builder server to cloud, to allow the connector builder UI to be opened in cloud for testing that addition.

## How
There are two ways to test this out:
1. Using the local `.experiments.json` file:
    - Create file at `airbyte-platform/airbyte-webapp/.experiments.json` with the contents
      ```
      {
        "connectorBuilder.showNavigationLinks": true
      }
      ```
    - Run `pnpm run start:cloud`
    - Click on the Builder button in the sidebar to open the connector builder route.
2. Using LaunchDarkly
    - Remove the `.experiments.json` value if you already enabled the experiment there
    - Run `pnpm run start:cloud`
    - Go to https://app.launchdarkly.com/, and log in with the dev-frontend@airbyte.io LaunchDarkly credentials from LastPass
    - Navigate to https://app.launchdarkly.com/default/test/features/connectorBuilder.showNavigationLinks/targeting, and add yourself as an individual target for the `true` value
    - The Builder navigation links should now show up in the webapp, use them to open the connector builder

The connector builder will actually work properly if you have a locally running OSS instance, because it makes requests to `localhost:3003` when calling the connector builder server. But when this is actually deployed to a dev environment or prod, the connector builder server calls will fail because there is not currently a connector builder server container running in cloud deployments. (I tried testing this out but failed to deploy this branch to cloud: https://github.com/airbytehq/airbyte-platform-internal/actions/runs/4288573761/jobs/7470749347, asked about this on slack [here](https://airbytehq-team.slack.com/archives/C046KQF5GBT/p1677548958003739))

## 🚨 User Impact 🚨
No user impact since this is hidden behind a feature flag.
