### PR TITLE
🪟🐛 Connector builder: Make sure control buttons don't submit 

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/Builder/BuilderList.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/BuilderList.tsx
@@ -41,6 +41,7 @@ export const BuilderList: React.FC<BuilderListProps> = ({ children, emptyItem, b
       ))}
       <div>
         <Button
+          type="button"
           variant="secondary"
           icon={<FontAwesomeIcon icon={faPlus} />}
           onClick={() => {

--- a/airbyte-webapp/src/components/connectorBuilder/Builder/RemoveButton.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/RemoveButton.tsx
@@ -5,7 +5,7 @@ import styles from "./RemoveButton.module.scss";
 
 export const RemoveButton = ({ onClick }: { onClick: () => void }) => {
   return (
-    <button className={styles.removeButton} onClick={onClick}>
+    <button type="button" className={styles.removeButton} onClick={onClick}>
       <FontAwesomeIcon icon={faXmark} />
     </button>
   );


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/23353

## How

The buttons used for the `BuilderList` were submit buttons accidentally submitting the form, causing the error described in the issue (not sure why it was only happening in Brave, but it's a general thing that should be fixed).
