### PR TITLE
🪟🐛 Connector builder: Add back defaults for incremental sync

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/Builder/IncrementalSection.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/IncrementalSection.tsx
@@ -24,12 +24,12 @@ export const IncrementalSection: React.FC<IncrementalSectionProps> = ({ streamFi
     if (newToggleValue) {
       helpers.setValue({
         type: "DatetimeBasedCursor",
-        cursor_field: "",
-        datetime_format: "",
-        cursor_granularity: "",
-        end_datetime: "",
+        datetime_format: "%Y-%m-%d %H:%M:%S.%f+00:00",
         start_datetime: "",
+        end_datetime: "{{ now_utc() }}",
         step: "",
+        cursor_field: "",
+        cursor_granularity: "",
       });
     } else {
       helpers.setValue(undefined);


### PR DESCRIPTION
During the cdk-to-beta cutover the defaults for datetime format and end_datetime got lost, this PR is adding them back

Removed here:
https://github.com/airbytehq/airbyte-platform/pull/102/files#diff-516f1bc1379d33482261f8642fbd118243e4e01e2afd94378c05262e5e1b9608L85