### PR TITLE
Helm charts should be published when pushing to Main, not Master

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -5,7 +5,7 @@ concurrency:
 on:
   push:
     branches:
-      - "master"
+      - "main"
     paths:
       - "charts/**"
       - "!charts/**/Chart.yaml"


### PR DESCRIPTION
## What
The workflow to push Helm charts used the old master branch naming scheme. However, the airbyte-platform repo is using the main naming scheme for branches. This discrepancy is causing the new Helm charts to not be published.

## How
Changing the worfklow from "on push to master" to "on push to main"

## Can this PR be safely reverted / rolled back?
- [X ] YES 💚
- [ ] NO ❌

