### PR TITLE
Bump helm chart version reference to 0.44.1

### DIFF
--- a/charts/airbyte-bootloader/Chart.yaml
+++ b/charts/airbyte-bootloader/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/airbyte-connector-builder-server/Chart.yaml
+++ b/charts/airbyte-connector-builder-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/airbyte-metrics/Chart.yaml
+++ b/charts/airbyte-metrics/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/airbyte-pod-sweeper/Chart.yaml
+++ b/charts/airbyte-pod-sweeper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/airbyte-server/Chart.yaml
+++ b/charts/airbyte-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/airbyte-temporal/Chart.yaml
+++ b/charts/airbyte-temporal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/airbyte-webapp/Chart.yaml
+++ b/charts/airbyte-webapp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/airbyte-worker/Chart.yaml
+++ b/charts/airbyte-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.43.22"
+version: "0.44.1"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/airbyte/Chart.lock
+++ b/charts/airbyte/Chart.lock
@@ -4,30 +4,30 @@ dependencies:
   version: 1.17.1
 - name: airbyte-bootloader
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: temporal
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: webapp
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: server
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: worker
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: pod-sweeper
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: metrics
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: cron
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
+  version: 0.44.1
 - name: connector-builder-server
   repository: https://airbytehq.github.io/helm-charts/
-  version: 0.43.22
-digest: sha256:3f86ccd42c1eb353dd2d45237b21706c6d8a1d564dc8babb26c0fd961c56ed9d
-generated: "2023-01-25T02:03:57.511452543Z"
+  version: 0.44.1
+digest: sha256:5744b32d3017cfa51d6ce284dee5005548cb3f940c120935145bc46bc8006cfc
+generated: "2023-02-14T01:44:36.918579107Z"

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.43.22
+version: 0.44.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,36 +32,36 @@ dependencies:
   - condition: airbyte-bootloader.enabled
     name: airbyte-bootloader
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: temporal.enabled
     name: temporal
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: webapp.enabled
     name: webapp
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: server.enabled
     name: server
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: worker.enabled
     name: worker
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: pod-sweeper.enabled
     name: pod-sweeper
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: metrics.enabled
     name: metrics
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: cron.enabled
     name: cron
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1
   - condition: connector-builder-server.enabled
     name: connector-builder-server
     repository: "https://airbytehq.github.io/helm-charts/"
-    version: 0.43.22
+    version: 0.44.1


### PR DESCRIPTION
## What
Migrating https://github.com/airbytehq/airbyte/pull/22964

## How
Gotta bump chart versions to match our published versions

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

This PR be safely reverted **until we have fixed helm chart publishing and published a new chart** with https://github.com/airbytehq/airbyte-platform/pull/153, but we probably don't want to revert.

## 🚨 User Impact 🚨
Helm chart yamls will now have a version that matches published charts! yay