### PR TITLE
fix(kubernetes): Exceptions in new KubePodProcess(...) can leak resources

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -416,215 +416,221 @@ public class KubePodProcess implements KubePod {
                         final Map<Integer, Integer> internalToExternalPorts,
                         final String... args)
       throws IOException, InterruptedException {
-    this.fabricClient = fabricClient;
-    this.stdoutLocalPort = stdoutLocalPort;
-    this.stderrLocalPort = stderrLocalPort;
-    this.stdoutServerSocket = new ServerSocket(stdoutLocalPort);
-    this.stderrServerSocket = new ServerSocket(stderrLocalPort);
-    this.executorService = Executors.newFixedThreadPool(2);
-    setupStdOutAndStdErrListeners();
+    try {
+      this.fabricClient = fabricClient;
+      this.stdoutLocalPort = stdoutLocalPort;
+      this.stderrLocalPort = stderrLocalPort;
+      this.stdoutServerSocket = new ServerSocket(stdoutLocalPort);
+      this.stderrServerSocket = new ServerSocket(stderrLocalPort);
+      this.executorService = Executors.newFixedThreadPool(2);
+      setupStdOutAndStdErrListeners();
 
-    if (entrypointOverride != null) {
-      LOGGER.info("Found entrypoint override: {}", entrypointOverride);
-    }
+      if (entrypointOverride != null) {
+        LOGGER.info("Found entrypoint override: {}", entrypointOverride);
+      }
 
-    final Volume pipeVolume = new VolumeBuilder()
-        .withName("airbyte-pipes")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
+      final Volume pipeVolume = new VolumeBuilder()
+          .withName("airbyte-pipes")
+          .withNewEmptyDir()
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount pipeVolumeMount = new VolumeMountBuilder()
-        .withName("airbyte-pipes")
-        .withMountPath(PIPES_DIR)
-        .build();
+      final VolumeMount pipeVolumeMount = new VolumeMountBuilder()
+          .withName("airbyte-pipes")
+          .withMountPath(PIPES_DIR)
+          .build();
 
-    final Volume configVolume = new VolumeBuilder()
-        .withName("airbyte-config")
-        .withNewEmptyDir()
-        .withMedium("Memory")
-        .endEmptyDir()
-        .build();
+      final Volume configVolume = new VolumeBuilder()
+          .withName("airbyte-config")
+          .withNewEmptyDir()
+          .withMedium("Memory")
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount configVolumeMount = new VolumeMountBuilder()
-        .withName("airbyte-config")
-        .withMountPath(CONFIG_DIR)
-        .build();
+      final VolumeMount configVolumeMount = new VolumeMountBuilder()
+          .withName("airbyte-config")
+          .withMountPath(CONFIG_DIR)
+          .build();
 
-    final Volume terminationVolume = new VolumeBuilder()
-        .withName("airbyte-termination")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
+      final Volume terminationVolume = new VolumeBuilder()
+          .withName("airbyte-termination")
+          .withNewEmptyDir()
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount terminationVolumeMount = new VolumeMountBuilder()
-        .withName("airbyte-termination")
-        .withMountPath(TERMINATION_DIR)
-        .build();
+      final VolumeMount terminationVolumeMount = new VolumeMountBuilder()
+          .withName("airbyte-termination")
+          .withMountPath(TERMINATION_DIR)
+          .build();
 
-    final Volume tmpVolume = new VolumeBuilder()
-        .withName("tmp")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
+      final Volume tmpVolume = new VolumeBuilder()
+          .withName("tmp")
+          .withNewEmptyDir()
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount tmpVolumeMount = new VolumeMountBuilder()
-        .withName("tmp")
-        .withMountPath(TMP_DIR)
-        .build();
+      final VolumeMount tmpVolumeMount = new VolumeMountBuilder()
+          .withName("tmp")
+          .withMountPath(TMP_DIR)
+          .build();
 
-    final Container init = getInit(usesStdin, List.of(pipeVolumeMount, configVolumeMount), busyboxImage);
-    final Container main = getMain(
-        image,
-        imagePullPolicy,
-        usesStdin,
-        entrypointOverride,
-        List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount, tmpVolumeMount),
-        resourceRequirements,
-        internalToExternalPorts,
-        envMap,
-        args);
+      final Container init = getInit(usesStdin, List.of(pipeVolumeMount, configVolumeMount), busyboxImage);
+      final Container main = getMain(
+          image,
+          imagePullPolicy,
+          usesStdin,
+          entrypointOverride,
+          List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount, tmpVolumeMount),
+          resourceRequirements,
+          internalToExternalPorts,
+          envMap,
+          args);
 
-    // Printing socat notice logs with socat -d -d
-    // To print info logs as well use socat -d -d -d
-    // more info: https://linux.die.net/man/1/socat
-    final io.fabric8.kubernetes.api.model.ResourceRequirements heartbeatSidecarResources =
-        getResourceRequirementsBuilder(DEFAULT_SIDECAR_RESOURCES).build();
-    final io.fabric8.kubernetes.api.model.ResourceRequirements socatSidecarResources =
-        getResourceRequirementsBuilder(DEFAULT_SOCAT_RESOURCES).build();
+      // Printing socat notice logs with socat -d -d
+      // To print info logs as well use socat -d -d -d
+      // more info: https://linux.die.net/man/1/socat
+      final io.fabric8.kubernetes.api.model.ResourceRequirements heartbeatSidecarResources =
+          getResourceRequirementsBuilder(DEFAULT_SIDECAR_RESOURCES).build();
+      final io.fabric8.kubernetes.api.model.ResourceRequirements socatSidecarResources =
+          getResourceRequirementsBuilder(DEFAULT_SOCAT_RESOURCES).build();
 
-    final Container remoteStdin = new ContainerBuilder()
-        .withName("remote-stdin")
-        .withImage(socatImage)
-        .withCommand("sh", "-c", "socat -d -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
-        .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
-        .withResources(socatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container remoteStdin = new ContainerBuilder()
+          .withName("remote-stdin")
+          .withImage(socatImage)
+          .withCommand("sh", "-c", "socat -d -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
+          .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
+          .withResources(socatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    final Container relayStdout = new ContainerBuilder()
-        .withName("relay-stdout")
-        .withImage(socatImage)
-        .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
-        .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
-        .withResources(socatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container relayStdout = new ContainerBuilder()
+          .withName("relay-stdout")
+          .withImage(socatImage)
+          .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
+          .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
+          .withResources(socatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    final Container relayStderr = new ContainerBuilder()
-        .withName("relay-stderr")
-        .withImage(socatImage)
-        .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
-        .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
-        .withResources(socatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container relayStderr = new ContainerBuilder()
+          .withName("relay-stderr")
+          .withImage(socatImage)
+          .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
+          .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
+          .withResources(socatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    // communicates via a file if it isn't able to reach the heartbeating server and succeeds if the
-    // main container completes
-    final String heartbeatCommand = MoreResources.readResource("entrypoints/sync/check.sh")
-        .replaceAll("TERMINATION_FILE_CHECK", TERMINATION_FILE_CHECK)
-        .replaceAll("TERMINATION_FILE_MAIN", TERMINATION_FILE_MAIN)
-        .replaceAll("HEARTBEAT_URL", kubeHeartbeatUrl);
+      // communicates via a file if it isn't able to reach the heartbeating server and succeeds if the
+      // main container completes
+      final String heartbeatCommand = MoreResources.readResource("entrypoints/sync/check.sh")
+          .replaceAll("TERMINATION_FILE_CHECK", TERMINATION_FILE_CHECK)
+          .replaceAll("TERMINATION_FILE_MAIN", TERMINATION_FILE_MAIN)
+          .replaceAll("HEARTBEAT_URL", kubeHeartbeatUrl);
 
-    final Container callHeartbeatServer = new ContainerBuilder()
-        .withName("call-heartbeat-server")
-        .withImage(curlImage)
-        .withCommand("sh")
-        .withArgs("-c", heartbeatCommand)
-        .withVolumeMounts(terminationVolumeMount)
-        .withResources(heartbeatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container callHeartbeatServer = new ContainerBuilder()
+          .withName("call-heartbeat-server")
+          .withImage(curlImage)
+          .withCommand("sh")
+          .withArgs("-c", heartbeatCommand)
+          .withVolumeMounts(terminationVolumeMount)
+          .withResources(heartbeatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    final List<Container> containers = usesStdin ? List.of(main, remoteStdin, relayStdout, relayStderr, callHeartbeatServer)
-        : List.of(main, relayStdout, relayStderr, callHeartbeatServer);
+      final List<Container> containers = usesStdin ? List.of(main, remoteStdin, relayStdout, relayStderr, callHeartbeatServer)
+          : List.of(main, relayStdout, relayStderr, callHeartbeatServer);
 
-    PodFluent.SpecNested<PodBuilder> podBuilder = new PodBuilder()
-        .withApiVersion("v1")
-        .withNewMetadata()
-        .withName(podName)
-        .withLabels(labels)
-        .withAnnotations(annotations)
-        .endMetadata()
-        .withNewSpec();
+      PodFluent.SpecNested<PodBuilder> podBuilder = new PodBuilder()
+          .withApiVersion("v1")
+          .withNewMetadata()
+          .withName(podName)
+          .withLabels(labels)
+          .withAnnotations(annotations)
+          .endMetadata()
+          .withNewSpec();
 
-    final List<LocalObjectReference> pullSecrets = imagePullSecrets
-        .stream()
-        .map(imagePullSecret -> new LocalObjectReference(imagePullSecret))
-        .collect(Collectors.toList());
+      final List<LocalObjectReference> pullSecrets = imagePullSecrets
+          .stream()
+          .map(imagePullSecret -> new LocalObjectReference(imagePullSecret))
+          .collect(Collectors.toList());
 
-    final Pod pod = podBuilder.withTolerations(buildPodTolerations(tolerations))
-        .withImagePullSecrets(pullSecrets) // An empty list or an empty LocalObjectReference turns this into a no-op setting.
-        .withNodeSelector(nodeSelectors)
-        .withRestartPolicy("Never")
-        .withInitContainers(init)
-        .withContainers(containers)
-        .withVolumes(pipeVolume, configVolume, terminationVolume, tmpVolume)
-        .endSpec()
-        .build();
+      final Pod pod = podBuilder.withTolerations(buildPodTolerations(tolerations))
+          .withImagePullSecrets(pullSecrets) // An empty list or an empty LocalObjectReference turns this into a no-op setting.
+          .withNodeSelector(nodeSelectors)
+          .withRestartPolicy("Never")
+          .withInitContainers(init)
+          .withContainers(containers)
+          .withVolumes(pipeVolume, configVolume, terminationVolume, tmpVolume)
+          .endSpec()
+          .build();
 
-    LOGGER.info("Creating pod {}...", pod.getMetadata().getName());
-    val start = System.currentTimeMillis();
+      LOGGER.info("Creating pod {}...", pod.getMetadata().getName());
+      val start = System.currentTimeMillis();
 
-    this.podDefinition = fabricClient.pods().inNamespace(namespace).createOrReplace(pod);
+      this.podDefinition = fabricClient.pods().inNamespace(namespace).createOrReplace(pod);
 
-    // We want to create a watch before the init container runs. Then we can guarantee
-    // that we're checking for updates across the full lifecycle of the main container.
-    // This is safe only because we are blocking the init pod until we copy files onto it.
-    // See the ExitCodeWatcher comments for more info.
-    exitCodeFuture = new CompletableFuture<>();
-    podInformer = fabricClient.pods()
-        .inNamespace(namespace)
-        .withName(pod.getMetadata().getName())
-        .inform();
-    podInformer.addEventHandler(new ExitCodeWatcher(
-        pod.getMetadata().getName(),
-        namespace,
-        exitCodeFuture::complete,
-        () -> {
-          LOGGER.info(prependPodInfo(
-              String.format(
-                  "Exit code watcher failed to retrieve the exit code. Defaulting to %s. This is expected if the job was cancelled.",
-                  KILLED_EXIT_CODE),
-              namespace,
-              podName));
+      // We want to create a watch before the init container runs. Then we can guarantee
+      // that we're checking for updates across the full lifecycle of the main container.
+      // This is safe only because we are blocking the init pod until we copy files onto it.
+      // See the ExitCodeWatcher comments for more info.
+      exitCodeFuture = new CompletableFuture<>();
+      podInformer = fabricClient.pods()
+          .inNamespace(namespace)
+          .withName(pod.getMetadata().getName())
+          .inform();
+      podInformer.addEventHandler(new ExitCodeWatcher(
+          pod.getMetadata().getName(),
+          namespace,
+          exitCodeFuture::complete,
+          () -> {
+            LOGGER.info(prependPodInfo(
+                String.format(
+                    "Exit code watcher failed to retrieve the exit code. Defaulting to %s. This is expected if the job was cancelled.",
+                    KILLED_EXIT_CODE),
+                namespace,
+                podName));
 
-          exitCodeFuture.complete(KILLED_EXIT_CODE);
-        }));
+            exitCodeFuture.complete(KILLED_EXIT_CODE);
+          }));
 
-    waitForInitPodToRun(fabricClient, podDefinition);
+      waitForInitPodToRun(fabricClient, podDefinition);
 
-    LOGGER.info("Copying files...");
-    copyFilesToKubeConfigVolume(fabricClient, podDefinition, files);
+      LOGGER.info("Copying files...");
+      copyFilesToKubeConfigVolume(fabricClient, podDefinition, files);
 
-    LOGGER.info("Waiting until pod is ready...");
-    // If a pod gets into a non-terminal error state it should be automatically killed by our
-    // heartbeating mechanism.
-    // This also handles the case where a very short pod already completes before this check completes
-    // the first time.
-    // This doesn't manage things like pods that are blocked from running for some cluster reason or if
-    // the init
-    // container got stuck somehow.
-    fabricClient.resource(podDefinition).waitUntilCondition(p -> {
-      final boolean isReady = Objects.nonNull(p) && Readiness.getInstance().isReady(p);
-      return isReady || KubePodResourceHelper.isTerminal(p);
-    }, 20, TimeUnit.MINUTES);
-    MetricClientFactory.getMetricClient().distribution(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS,
-        System.currentTimeMillis() - start);
+      LOGGER.info("Waiting until pod is ready...");
+      // If a pod gets into a non-terminal error state it should be automatically killed by our
+      // heartbeating mechanism.
+      // This also handles the case where a very short pod already completes before this check completes
+      // the first time.
+      // This doesn't manage things like pods that are blocked from running for some cluster reason or if
+      // the init
+      // container got stuck somehow.
+      fabricClient.resource(podDefinition).waitUntilCondition(p -> {
+        final boolean isReady = Objects.nonNull(p) && Readiness.getInstance().isReady(p);
+        return isReady || KubePodResourceHelper.isTerminal(p);
+      }, 20, TimeUnit.MINUTES);
+      MetricClientFactory.getMetricClient().distribution(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS,
+          System.currentTimeMillis() - start);
 
-    // allow writing stdin to pod
-    LOGGER.info("Reading pod IP...");
-    final var podIp = getPodIP(fabricClient, podName, namespace);
-    LOGGER.info("Pod IP: {}", podIp);
+      // allow writing stdin to pod
+      LOGGER.info("Reading pod IP...");
+      final var podIp = getPodIP(fabricClient, podName, namespace);
+      LOGGER.info("Pod IP: {}", podIp);
 
-    if (usesStdin) {
-      LOGGER.info("Creating stdin socket...");
-      final var socketToDestStdIo = new Socket(podIp, STDIN_REMOTE_PORT);
-      this.stdin = socketToDestStdIo.getOutputStream();
-    } else {
-      LOGGER.info("Using null stdin output stream...");
-      this.stdin = NullOutputStream.NULL_OUTPUT_STREAM;
+      if (usesStdin) {
+        LOGGER.info("Creating stdin socket...");
+        final var socketToDestStdIo = new Socket(podIp, STDIN_REMOTE_PORT);
+        this.stdin = socketToDestStdIo.getOutputStream();
+      } else {
+        LOGGER.info("Using null stdin output stream...");
+        this.stdin = NullOutputStream.NULL_OUTPUT_STREAM;
+      }
+    } catch (Exception e) {
+      // We need to make sure the ports are offered back
+      cleanup();
+      throw e; // Throw the exception again to inform the caller
     }
   }
 
@@ -681,6 +687,19 @@ public class KubePodProcess implements KubePod {
    */
   @Override
   public void destroy() {
+    cleanup();
+  }
+
+  /**
+   * cleanup destroys and returns any resources it has consumed this is a private method so that the
+   * constructor may call it.
+   */
+  private void cleanup() {
+    if (this.podDefinition == null) {
+      // no pod to destroy; just close resources
+      close();
+      return;
+    }
     final String podName = podDefinition.getMetadata().getName();
     final String podNamespace = podDefinition.getMetadata().getNamespace();
 
@@ -744,10 +763,18 @@ public class KubePodProcess implements KubePod {
       Exceptions.swallow(this.stderr::close);
     }
 
-    Exceptions.swallow(this.stdoutServerSocket::close);
-    Exceptions.swallow(this.stderrServerSocket::close);
-    Exceptions.swallow(this.podInformer::close);
-    Exceptions.swallow(this.executorService::shutdownNow);
+    if (this.stdoutServerSocket != null) {
+      Exceptions.swallow(this.stdoutServerSocket::close);
+    }
+    if (this.stderrServerSocket != null) {
+      Exceptions.swallow(this.stderrServerSocket::close);
+    }
+    if (this.podInformer != null) {
+      Exceptions.swallow(this.podInformer::close);
+    }
+    if (this.executorService != null) {
+      Exceptions.swallow(this.executorService::shutdownNow);
+    }
 
     KubePortManagerSingleton.getInstance().offer(stdoutLocalPort);
     KubePortManagerSingleton.getInstance().offer(stderrLocalPort);


### PR DESCRIPTION
## What

If `KubePodProcess` fails to initialize its constructor, the `destroy()` method is never called, so the ports remain claimed. this will eventually lead to port exhaustion:

```
	at io.airbyte.workers.process.KubePodProcess.<init>(KubePodProcess.java:561) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
```

### Stack Trace
```
2023-04-06 14:12:53 ERROR i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):599 - [ACTIVITY-FAILURE] Connection 40e0fad2-29c4-4d9b-a083-3ec7a2bae764 failed to run an activity.(CheckConnectionInput).  Connection manager workflow will be restarted after a delay of PT10M.
io.temporal.failure.ActivityFailure: scheduledEventId=55, startedEventId=56, activityType='RunWithJobOutput', activityId='0bc011bb-5a54-3967-9b5b-db82ef4c501c', identity='1@airbyte-worker-7ddb65b76d-l7c8n', retryState=RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
	at java.lang.Thread.getStackTrace(Thread.java:2550) ~[?:?]
	at io.temporal.internal.sync.ActivityStubBase.execute(ActivityStubBase.java:49) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.ActivityInvocationHandler.lambda$getActivityFunc$0(ActivityInvocationHandler.java:78) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.ActivityInvocationHandlerBase.invoke(ActivityInvocationHandlerBase.java:60) ~[temporal-sdk-1.17.0.jar:?]
	at jdk.proxy2.$Proxy106.runWithJobOutput(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivityWithOutput(ConnectionManagerWorkflowImpl.java:597) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.getCheckResponse(ConnectionManagerWorkflowImpl.java:377) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.checkConnections(ConnectionManagerWorkflowImpl.java:438) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.lambda$generateSyncWorkflowRunnable$1(ConnectionManagerWorkflowImpl.java:239) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102) ~[temporal-sdk-1.17.0.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.run(ConnectionManagerWorkflowImpl.java:152) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at ConnectionManagerWorkflowImplProxy.run$accessor$j7DJrfKe(Unknown Source) ~[?:?]
	at ConnectionManagerWorkflowImplProxy$auxiliary$CxqyrxnC.call(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.support.TemporalActivityStubInterceptor.execute(TemporalActivityStubInterceptor.java:79) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at ConnectionManagerWorkflowImplProxy.run(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:302) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:277) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:71) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:116) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:106) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.worker.ActiveThreadReportingExecutor.lambda$submit$0(ActiveThreadReportingExecutor.java:53) ~[temporal-sdk-1.17.0.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
Caused by: io.temporal.failure.ApplicationFailure: message='io.airbyte.workers.exception.WorkerException: Unexpected error while getting checking connection.', type='java.util.concurrent.ExecutionException', nonRetryable=false
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?]
	at io.airbyte.workers.temporal.TemporalAttemptExecution.get(TemporalAttemptExecution.java:167) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at io.airbyte.workers.temporal.check.connection.CheckConnectionActivityImpl.runWithJobOutput(CheckConnectionActivityImpl.java:118) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
	at io.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:95) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:92) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handleActivity(ActivityWorker.java:241) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:206) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:179) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93) ~[temporal-sdk-1.17.0.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1589) ~[?:?]
Caused by: io.temporal.failure.ApplicationFailure: message='Unexpected error while getting checking connection.', type='io.airbyte.workers.exception.WorkerException', nonRetryable=false
	at io.airbyte.workers.general.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:132) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.general.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:44) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$6(TemporalAttemptExecution.java:202) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1589) ~[?:?]
Caused by: io.temporal.failure.ApplicationFailure: message='Failure executing: POST at: https://172.20.0.1/api/v1/namespaces/airbyte/pods. Message: Unauthorized! Configured service account doesn't have access. Service account may have been revoked. Unauthorized.', type='io.airbyte.workers.exception.WorkerException', nonRetryable=false
	at io.airbyte.workers.process.KubeProcessFactory.create(KubeProcessFactory.java:148) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.process.AirbyteIntegrationLauncher.check(AirbyteIntegrationLauncher.java:106) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.general.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:74) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.general.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:44) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$6(TemporalAttemptExecution.java:202) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1589) ~[?:?]
Caused by: io.temporal.failure.ApplicationFailure: message='Failure executing: POST at: https://172.20.0.1/api/v1/namespaces/airbyte/pods. Message: Unauthorized! Configured service account doesn't have access. Service account may have been revoked. Unauthorized.', type='io.fabric8.kubernetes.client.KubernetesClientException', nonRetryable=false
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:682) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:661) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:610) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:555) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:518) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:305) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:644) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:83) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.CreateOnlyResourceOperation.create(CreateOnlyResourceOperation.java:61) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:48) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:318) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:83) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:308) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:83) ~[kubernetes-client-5.12.2.jar:?]
	at io.airbyte.workers.process.KubePodProcess.<init>(KubePodProcess.java:561) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.process.KubeProcessFactory.create(KubeProcessFactory.java:144) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.process.AirbyteIntegrationLauncher.check(AirbyteIntegrationLauncher.java:106) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.general.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:74) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.general.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:44) ~[io.airbyte-airbyte-commons-worker-0.42.0.jar:?]
	at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$6(TemporalAttemptExecution.java:202) ~[io.airbyte-airbyte-workers-0.42.0.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1589) ~[?:?]
```



## How

This fix changes `KubePodProcess` constructor such that it catches any Exception during the initialization phase.
If it does detect an error, it will call `destroy()` which offers the claimed ports back to the worker, and cleans up any other resources. Finally, it will re-throw the exception to inform the caller.

*NOTE*: I'd rather reclaim the ports in `KubeProcessFactory`; but the catch doesn't have access to a fully constructed `KubePodProcess` object to run `destroy()` on it. It could `offer()` those ports back manually but they are effectively being handed off for `KubePodProcess` to own as part of construction; so dealing with this case is a bit awkward since `KubePodProcess` would have to do all the cleanup EXCEPT offering the ports back -- and then the Factory would offer them back in the exception handler -- It seems perhaps messier to do it that way.

As a future refactoring idea: I'd recommend doing less stuff inside the KubePodProcess constructor; and perhaps create an `init()` method that the Factory can call  after construction; allowing it to capture the error and call `destroy()` itself.

## Recommended reading order
1. `airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePodProcess.java`

## Can this PR be safely reverted / rolled back?
- [x] YES 💚


## 🚨 User Impact 🚨
No