### PR TITLE
feat(kubernetes): define separate readiness and liveness endpoints for k8s probes

### DIFF
--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/HealthCheckHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/HealthCheckHandler.java
@@ -6,8 +6,15 @@ package io.airbyte.commons.server.handlers;
 
 import io.airbyte.api.model.generated.HealthCheckRead;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.micronaut.context.event.ShutdownEvent;
+import io.micronaut.runtime.event.annotation.EventListener;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * HealthCheckHandler. Javadocs suppressed because api docs should be used as source of truth.
@@ -18,12 +25,36 @@ public class HealthCheckHandler {
 
   private final ConfigRepository repository;
 
+  private final AtomicBoolean ready = new AtomicBoolean(false);
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   public HealthCheckHandler(@Named("configRepository") final ConfigRepository repository) {
     this.repository = repository;
   }
 
+  @EventListener
+  public void onServerStartupEvent(ServerStartupEvent event) {
+    log.info("ServerStartupEvent received: setting health status to READY");
+    this.ready.set(true);
+  }
+
+  @EventListener
+  public void onShutdownEvent(ShutdownEvent event) {
+    log.info("ShutdownEvent received: setting health status to NOT READY");
+    this.ready.set(false);
+  }
+
   public HealthCheckRead health() {
     return new HealthCheckRead().available(repository.healthCheck());
+  }
+
+  public boolean isReady() {
+    return this.ready.get();
+  }
+
+  public void setReady(boolean ready) {
+    this.ready.set(ready);
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/LivenessIndicator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/LivenessIndicator.java
@@ -7,6 +7,7 @@ package io.airbyte.server.heath.indicator;
 import io.micronaut.health.HealthStatus;
 import io.micronaut.management.health.indicator.AbstractHealthIndicator;
 import io.micronaut.management.health.indicator.annotation.Liveness;
+import jakarta.inject.Singleton;
 import java.util.Map;
 
 /**
@@ -15,6 +16,7 @@ import java.util.Map;
  * Kubernetes)
  */
 @Liveness
+@Singleton
 public class LivenessIndicator extends AbstractHealthIndicator<Map<String, Object>> {
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/LivenessIndicator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/LivenessIndicator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.heath.indicator;
+
+import io.micronaut.health.HealthStatus;
+import io.micronaut.management.health.indicator.AbstractHealthIndicator;
+import io.micronaut.management.health.indicator.annotation.Liveness;
+import java.util.Map;
+
+/**
+ * LivenessIndicator is a Micronaut health indicator that indicates if the server is alive. When the
+ * server is not alive, it indicates that it should be restarted by the platform orchestrator (e.g.
+ * Kubernetes)
+ */
+@Liveness
+public class LivenessIndicator extends AbstractHealthIndicator<Map<String, Object>> {
+
+  @Override
+  protected Map<String, Object> getHealthInformation() {
+    Map<String, Object> details = Map.of("alive", true);
+    this.healthStatus = HealthStatus.UP;
+    return details;
+  }
+
+  @Override
+  protected String getName() {
+    return "liveness";
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/ReadinessIndicator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/ReadinessIndicator.java
@@ -4,9 +4,12 @@
 
 package io.airbyte.server.heath.indicator;
 
+import io.airbyte.commons.server.handlers.HealthCheckHandler;
 import io.micronaut.health.HealthStatus;
 import io.micronaut.management.health.indicator.AbstractHealthIndicator;
 import io.micronaut.management.health.indicator.annotation.Readiness;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.util.Map;
 
 /**
@@ -15,12 +18,21 @@ import java.util.Map;
  * shutting down.
  */
 @Readiness
+@Singleton
 public class ReadinessIndicator extends AbstractHealthIndicator<Map<String, Object>> {
+
+  @Inject
+  private HealthCheckHandler healthCheckHandler;
 
   @Override
   protected Map<String, Object> getHealthInformation() {
-    Map<String, Object> details = Map.of("ready", true);
-    this.healthStatus = HealthStatus.UP;
+    var ready = healthCheckHandler.isReady();
+    Map<String, Object> details = Map.of("ready", ready);
+    if (ready) {
+      this.healthStatus = HealthStatus.UP;
+    } else {
+      this.healthStatus = HealthStatus.DOWN;
+    }
     return details;
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/ReadinessIndicator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/heath/indicator/ReadinessIndicator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.heath.indicator;
+
+import io.micronaut.health.HealthStatus;
+import io.micronaut.management.health.indicator.AbstractHealthIndicator;
+import io.micronaut.management.health.indicator.annotation.Readiness;
+import java.util.Map;
+
+/**
+ * ReadinessIndicator is a Micronaut health indicator that indicates if the server is ready to serve
+ * traffic. A server is ready when it is listening for connections, and it is not in the process of
+ * shutting down.
+ */
+@Readiness
+public class ReadinessIndicator extends AbstractHealthIndicator<Map<String, Object>> {
+
+  @Override
+  protected Map<String, Object> getHealthInformation() {
+    Map<String, Object> details = Map.of("ready", true);
+    this.healthStatus = HealthStatus.UP;
+    return details;
+  }
+
+  @Override
+  protected String getName() {
+    return "readiness";
+  }
+
+}

--- a/airbyte-server/src/main/resources/application.yml
+++ b/airbyte-server/src/main/resources/application.yml
@@ -25,6 +25,9 @@ micronaut:
     netty:
       access-logger:
         enabled: ${HTTP_ACCESS_LOG_ENABLED:true}
+        exclusions:
+          - /health
+          - /health/.+
     idle-timeout: ${HTTP_IDLE_TIMEOUT:5m}
 
 airbyte:
@@ -140,10 +143,16 @@ endpoints:
     enabled: true
     sensitive: false
   health:
-    enabled: false
+    enabled: ${HEALTH_ENDPOINT_ENABLED:true}
     jdbc:
       enabled: false
     sensitive: false
+    details-visible: ${HEALTH_ENDPOINT_DETAILS_VISIBLE:AUTHENTICATED}
+    status:
+      http-mapping:
+        UP: ${HEALTH_ENDPOINT_UP_HTTP_CODE:200}
+        UNKNOWN: ${HEALTH_ENDPOINT_UNKNOWN_HTTP_CODE:200}
+        DOWN: ${HEALTH_ENDPOINT_DOWN_HTTP_CODE:503}
   info:
     enabled: true
     sensitive: true

--- a/airbyte-server/src/test/java/io/airbyte/server/health/indicator/BaseIndicatorTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/health/indicator/BaseIndicatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.health.indicator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.airbyte.commons.server.handlers.HealthCheckHandler;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.mockito.Mockito;
+
+/**
+ * Abstract test class for health indicators.
+ */
+@MicronautTest
+@Requires(property = "mockito.test.enabled",
+          defaultValue = StringUtils.TRUE,
+          value = StringUtils.TRUE)
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
+abstract class BaseIndicatorTest {
+
+  HealthCheckHandler healthCheckHandler = Mockito.mock(HealthCheckHandler.class);
+
+  @MockBean(HealthCheckHandler.class)
+  @Replaces(HealthCheckHandler.class)
+  HealthCheckHandler mmHealthCheckHandler() {
+    return healthCheckHandler;
+  }
+
+  @Inject
+  @Client("/")
+  HttpClient client;
+
+  void testEndpointStatus(final HttpRequest request, final HttpStatus expectedStatus) {
+    assertEquals(expectedStatus, client.toBlocking().exchange(request).getStatus());
+  }
+
+  void testErrorEndpointStatus(final HttpRequest request, final HttpStatus expectedStatus) {
+    Assertions.assertThatThrownBy(() -> client.toBlocking().exchange(request))
+        .isInstanceOf(HttpClientResponseException.class)
+        .asInstanceOf(new InstanceOfAssertFactory(HttpClientResponseException.class, Assertions::assertThat))
+        .has(new Condition<HttpClientResponseException>(exception -> exception.getStatus() == expectedStatus,
+            "Http status to be %s", expectedStatus));
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/health/indicator/LivenessIndicatorTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/health/indicator/LivenessIndicatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.health.indicator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the liveness indicator probe endpoint.
+ */
+@MicronautTest
+@Requires(property = "mockito.test.enabled",
+          defaultValue = StringUtils.TRUE,
+          value = StringUtils.TRUE)
+@Requires(env = {Environment.TEST})
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+class LivenessIndicatorTest extends BaseIndicatorTest {
+
+  final String path = "/health/liveness";
+
+  @Test
+  void testLivenessEndpoint() {
+    testEndpointStatus(HttpRequest.GET(path), HttpStatus.OK);
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/health/indicator/ReadinessIndicatorTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/health/indicator/ReadinessIndicatorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.health.indicator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests the readiness indicator probe endpoint.
+ */
+@MicronautTest
+@Requires(property = "mockito.test.enabled",
+          defaultValue = StringUtils.TRUE,
+          value = StringUtils.TRUE)
+@Requires(env = {Environment.TEST})
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+class ReadinessIndicatorTest extends BaseIndicatorTest {
+
+  final String path = "/health/readiness";
+
+  @Test
+  void testReadinessEndpointSuccess() {
+    Mockito.when(healthCheckHandler.isReady()).thenReturn(true);
+    testEndpointStatus(HttpRequest.GET(path), HttpStatus.OK);
+  }
+
+  @Test
+  void testReadinessEndpointFailure() {
+    Mockito.when(healthCheckHandler.isReady()).thenReturn(false);
+    testErrorEndpointStatus(HttpRequest.GET(path), HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+}

--- a/charts/airbyte-bootloader/README.md
+++ b/charts/airbyte-bootloader/README.md
@@ -1,6 +1,6 @@
 # airbyte-bootloader
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte-bootloader
 
@@ -15,18 +15,25 @@ Helm chart to deploy airbyte-bootloader
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| containerSecurityContext | object | `{}` |  |
 | enabled | bool | `true` |  |
 | env_vars | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
+| global.database.host | string | `"example.com"` |  |
+| global.database.port | string | `"5432"` |  |
 | global.database.secretName | string | `""` |  |
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.env_vars | object | `{}` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.secrets | object | `{}` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
@@ -34,6 +41,7 @@ Helm chart to deploy airbyte-bootloader
 | image.repository | string | `"airbyte/bootloader"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
 | secrets | object | `{}` |  |

--- a/charts/airbyte-connector-builder-server/README.md
+++ b/charts/airbyte-connector-builder-server/README.md
@@ -1,8 +1,8 @@
-# server
+# connector-builder-server
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
-Helm chart to deploy airbyte-server
+Helm chart to deploy airbyte-connector-builder-server
 
 ## Requirements
 
@@ -16,6 +16,8 @@ Helm chart to deploy airbyte-server
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | containerSecurityContext | object | `{}` |  |
+| debug.enabled | bool | `false` |  |
+| debug.remoteDebugPort | int | `5005` |  |
 | enabled | bool | `true` |  |
 | env_vars | object | `{}` |  |
 | extraContainers | list | `[]` |  |
@@ -31,26 +33,12 @@ Helm chart to deploy airbyte-server
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
-| global.logs.accessKey.existingSecret | string | `""` |  |
-| global.logs.accessKey.existingSecretKey | string | `""` |  |
-| global.logs.accessKey.password | string | `"minio"` |  |
-| global.logs.externalMinio.enabled | bool | `false` |  |
-| global.logs.externalMinio.host | string | `"localhost"` |  |
-| global.logs.externalMinio.port | int | `9000` |  |
-| global.logs.gcs.bucket | string | `""` |  |
-| global.logs.gcs.credentials | string | `""` |  |
-| global.logs.gcs.credentialsJson | string | `""` |  |
-| global.logs.minio.enabled | bool | `true` |  |
-| global.logs.s3.bucket | string | `"airbyte-dev-logs"` |  |
-| global.logs.s3.bucketRegion | string | `""` |  |
-| global.logs.s3.enabled | bool | `false` |  |
-| global.logs.secretKey.existingSecret | string | `""` |  |
-| global.logs.secretKey.existingSecretKey | string | `""` |  |
-| global.logs.secretKey.password | string | `"minio123"` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"airbyte/server"` |  |
+| image.repository | string | `"airbyte/connector-atelier-server"` |  |
 | livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.initialDelaySeconds | int | `30` |  |
@@ -71,8 +59,8 @@ Helm chart to deploy airbyte-server
 | resources.requests | object | `{}` |  |
 | secrets | object | `{}` |  |
 | service.annotations | object | `{}` |  |
-| service.port | int | `8001` |  |
-| service.type | string | `"ClusterIP"` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"NodePort"` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/airbyte-cron/README.md
+++ b/charts/airbyte-cron/README.md
@@ -1,6 +1,6 @@
-# airbyte-cron
+# cron
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.17](https://img.shields.io/badge/AppVersion-0.40.17-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte-cron
 
@@ -21,6 +21,8 @@ Helm chart to deploy airbyte-cron
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.configMapName | string | `""` |  |
@@ -30,7 +32,10 @@ Helm chart to deploy airbyte-cron
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
+| global.secrets | object | `{}` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"airbyte/cron"` |  |
@@ -42,6 +47,7 @@ Helm chart to deploy airbyte-cron
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.containerSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |

--- a/charts/airbyte-metrics/README.md
+++ b/charts/airbyte-metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.3](https://img.shields.io/badge/AppVersion-0.40.3-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.3](https://img.shields.io/badge/AppVersion-0.40.3-informational?style=flat-square)
 
 Helm chart to deploy airbyte-metrics
 
@@ -33,6 +33,7 @@ Helm chart to deploy airbyte-metrics
 | image.repository | string | `"airbyte/metrics-reporter"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |

--- a/charts/airbyte-pod-sweeper/README.md
+++ b/charts/airbyte-pod-sweeper/README.md
@@ -1,6 +1,6 @@
 # pod-sweeper
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.37-alpha](https://img.shields.io/badge/AppVersion-0.39.37--alpha-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.37-alpha](https://img.shields.io/badge/AppVersion-0.39.37--alpha-informational?style=flat-square)
 
 Helm chart to deploy airbyte-pod-sweeper
 
@@ -56,16 +56,21 @@ Helm chart to deploy airbyte-pod-sweeper
 | livenessProbe.periodSeconds | int | `30` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `1` |  |
+| namespace | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
 | readinessProbe.periodSeconds | int | `30` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
+| timeToDeletePods.completed | int | `120` |  |
+| timeToDeletePods.error | int | `1440` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/airbyte-server/README.md
+++ b/charts/airbyte-server/README.md
@@ -1,6 +1,6 @@
 # server
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte-server
 
@@ -16,11 +16,16 @@ Helm chart to deploy airbyte-server
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | containerSecurityContext | object | `{}` |  |
+| debug.enabled | bool | `false` |  |
+| debug.remoteDebugPort | int | `5005` |  |
+| deploymentStrategyType | string | `"Recreate"` |  |
 | enabled | bool | `true` |  |
 | env_vars | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.configMapName | string | `""` |  |
@@ -31,6 +36,8 @@ Helm chart to deploy airbyte-server
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.logs.accessKey.existingSecret | string | `""` |  |
 | global.logs.accessKey.existingSecretKey | string | `""` |  |
 | global.logs.accessKey.password | string | `"minio"` |  |
@@ -53,16 +60,19 @@ Helm chart to deploy airbyte-server
 | image.repository | string | `"airbyte/server"` |  |
 | livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
-| livenessProbe.initialDelaySeconds | int | `30` |  |
+| livenessProbe.httpPath | string | `"/api/v1/health"` |  |
+| livenessProbe.initialDelaySeconds | int | `60` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | log.level | string | `"INFO"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
-| readinessProbe.initialDelaySeconds | int | `10` |  |
+| readinessProbe.httpPath | string | `"/api/v1/health"` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
 | readinessProbe.periodSeconds | int | `10` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `1` |  |

--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -262,7 +262,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /api/v1/health
+            path: {{ .Values.livenessProbe.httpPath | default "/api/v1/health" }}
             port: http
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -273,7 +273,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /api/v1/health
+            path: {{ .Values.readinessProbe.httpPath | default "/api/v1/health" }}
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/airbyte-server/values.yaml
+++ b/charts/airbyte-server/values.yaml
@@ -93,6 +93,7 @@ containerSecurityContext: {}
 ## Configure extra options for the server containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ##  livenessProbe.enabled Enable livenessProbe on the server
+##  livenessProbe.enabled HTTP path used for livenessProbe
 ##  livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
 ##  livenessProbe.periodSeconds Period seconds for livenessProbe
 ##  livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -102,12 +103,14 @@ containerSecurityContext: {}
 livenessProbe:
   enabled: true
   initialDelaySeconds: 60
+  httpPath: "/api/v1/health"
   periodSeconds: 10
   timeoutSeconds: 1
   failureThreshold: 3
   successThreshold: 1
 
 ##  readinessProbe.enabled Enable readinessProbe on the server
+##  readinessProbe.httpPath HTTP path used for readinessProbe
 ##  readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
 ##  readinessProbe.periodSeconds Period seconds for readinessProbe
 ##  readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -117,6 +120,7 @@ livenessProbe:
 readinessProbe:
   enabled: true
   initialDelaySeconds: 30
+  httpPath: "/api/v1/health"
   periodSeconds: 10
   timeoutSeconds: 1
   failureThreshold: 3

--- a/charts/airbyte-temporal/README.md
+++ b/charts/airbyte-temporal/README.md
@@ -1,6 +1,6 @@
 # temporal
 
-![Version: 0.40.33](https://img.shields.io/badge/Version-0.40.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.17](https://img.shields.io/badge/AppVersion-0.40.17-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte-temporal
 
@@ -21,6 +21,8 @@ Helm chart to deploy airbyte-temporal
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.configMapName | string | `""` |  |
@@ -30,6 +32,8 @@ Helm chart to deploy airbyte-temporal
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -43,6 +47,7 @@ Helm chart to deploy airbyte-temporal
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |

--- a/charts/airbyte-webapp/README.md
+++ b/charts/airbyte-webapp/README.md
@@ -1,6 +1,6 @@
 # webapp
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte-webapp
 
@@ -22,6 +22,8 @@ Helm chart to deploy airbyte-webapp
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullstory.enabled | bool | `false` |  |
@@ -32,6 +34,8 @@ Helm chart to deploy airbyte-webapp
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -49,8 +53,10 @@ Helm chart to deploy airbyte-webapp
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
+| readinessProbe.httpPath | string | `"/api/v1/health"` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |
 | readinessProbe.periodSeconds | int | `10` |  |
 | readinessProbe.successThreshold | int | `1` |  |

--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /api/v1/health
+            path: { .Values.readinessProbe.httpPath | default "/api/v1/health" }}
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/airbyte-webapp/values.yaml
+++ b/charts/airbyte-webapp/values.yaml
@@ -59,6 +59,7 @@ livenessProbe:
   successThreshold: 1
 
 ##  webapp.readinessProbe.enabled Enable readinessProbe on the webapp
+##  webapp.readinessProbe.httpPath HTTP path used for readinessProbe
 ##  webapp.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
 ##  webapp.readinessProbe.periodSeconds Period seconds for readinessProbe
 ##  webapp.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -67,6 +68,7 @@ livenessProbe:
 ##
 readinessProbe:
   enabled: true
+  httpPath: "/api/v1/health"
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 1

--- a/charts/airbyte-worker/README.md
+++ b/charts/airbyte-worker/README.md
@@ -1,6 +1,6 @@
 # worker
 
-![Version: 0.44.7](https://img.shields.io/badge/Version-0.44.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte-worker
 
@@ -16,6 +16,8 @@ Helm chart to deploy airbyte-worker
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | containerSecurityContext | object | `{}` |  |
+| debug.enabled | bool | `false` |  |
+| debug.remoteDebugPort | int | `5005` |  |
 | enabled | bool | `true` |  |
 | env_vars | object | `{}` |  |
 | extraContainers | list | `[]` |  |
@@ -64,7 +66,7 @@ Helm chart to deploy airbyte-worker
 | image.repository | string | `"airbyte/worker"` |  |
 | livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
-| livenessProbe.initialDelaySeconds | int | `30` |  |
+| livenessProbe.initialDelaySeconds | int | `50` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `1` |  |

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -1,6 +1,6 @@
 # airbyte
 
-![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
+![Version: 0.45.20](https://img.shields.io/badge/Version-0.45.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
 
 Helm chart to deploy airbyte
 
@@ -8,15 +8,15 @@ Helm chart to deploy airbyte
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://airbytehq.github.io/helm-charts/ | airbyte-bootloader | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | connector-builder-server | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | cron | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | metrics | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | pod-sweeper | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | server | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | temporal | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | webapp | 0.50.0 |
-| https://airbytehq.github.io/helm-charts/ | worker | 0.50.0 |
+| https://airbytehq.github.io/helm-charts/ | airbyte-bootloader | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | connector-builder-server | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | cron | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | metrics | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | pod-sweeper | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | server | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | temporal | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | webapp | 0.45.20 |
+| https://airbytehq.github.io/helm-charts/ | worker | 0.45.20 |
 | https://charts.bitnami.com/bitnami | common | 1.x.x |
 
 ## Values
@@ -44,7 +44,19 @@ Helm chart to deploy airbyte
 | connector-builder-server.env_vars | object | `{}` |  |
 | connector-builder-server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | connector-builder-server.image.repository | string | `"airbyte/connector-atelier-server"` |  |
+| connector-builder-server.livenessProbe.enabled | bool | `true` |  |
+| connector-builder-server.livenessProbe.failureThreshold | int | `3` |  |
+| connector-builder-server.livenessProbe.initialDelaySeconds | int | `30` |  |
+| connector-builder-server.livenessProbe.periodSeconds | int | `10` |  |
+| connector-builder-server.livenessProbe.successThreshold | int | `1` |  |
+| connector-builder-server.livenessProbe.timeoutSeconds | int | `1` |  |
 | connector-builder-server.log.level | string | `"INFO"` |  |
+| connector-builder-server.readinessProbe.enabled | bool | `true` |  |
+| connector-builder-server.readinessProbe.failureThreshold | int | `3` |  |
+| connector-builder-server.readinessProbe.initialDelaySeconds | int | `10` |  |
+| connector-builder-server.readinessProbe.periodSeconds | int | `10` |  |
+| connector-builder-server.readinessProbe.successThreshold | int | `1` |  |
+| connector-builder-server.readinessProbe.timeoutSeconds | int | `1` |  |
 | connector-builder-server.replicaCount | int | `1` |  |
 | connector-builder-server.resources.limits | object | `{}` |  |
 | connector-builder-server.resources.requests | object | `{}` |  |
@@ -95,6 +107,7 @@ Helm chart to deploy airbyte
 | global.database.secretName | string | `""` |  |
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
+| global.env_vars | object | `{}` |  |
 | global.jobs.kube.annotations | object | `{}` |  |
 | global.jobs.kube.images.busybox | string | `""` |  |
 | global.jobs.kube.images.curl | string | `""` |  |
@@ -197,6 +210,7 @@ Helm chart to deploy airbyte
 | server.image.repository | string | `"airbyte/server"` |  |
 | server.livenessProbe.enabled | bool | `true` |  |
 | server.livenessProbe.failureThreshold | int | `3` |  |
+| server.livenessProbe.httpPath | string | `"/api/v1/health"` |  |
 | server.livenessProbe.initialDelaySeconds | int | `30` |  |
 | server.livenessProbe.periodSeconds | int | `10` |  |
 | server.livenessProbe.successThreshold | int | `1` |  |
@@ -207,6 +221,7 @@ Helm chart to deploy airbyte
 | server.podLabels | object | `{}` |  |
 | server.readinessProbe.enabled | bool | `true` |  |
 | server.readinessProbe.failureThreshold | int | `3` |  |
+| server.readinessProbe.httpPath | string | `"/api/v1/health"` |  |
 | server.readinessProbe.initialDelaySeconds | int | `10` |  |
 | server.readinessProbe.periodSeconds | int | `10` |  |
 | server.readinessProbe.successThreshold | int | `1` |  |
@@ -272,6 +287,7 @@ Helm chart to deploy airbyte
 | webapp.podLabels | object | `{}` |  |
 | webapp.readinessProbe.enabled | bool | `true` |  |
 | webapp.readinessProbe.failureThreshold | int | `3` |  |
+| webapp.readinessProbe.httpPath | string | `"/api/v1/health"` |  |
 | webapp.readinessProbe.initialDelaySeconds | int | `10` |  |
 | webapp.readinessProbe.periodSeconds | int | `10` |  |
 | webapp.readinessProbe.successThreshold | int | `1` |  |
@@ -291,6 +307,8 @@ Helm chart to deploy airbyte
 | worker.containerOrchestrator.enabled | bool | `true` |  |
 | worker.containerOrchestrator.image | string | `""` |  |
 | worker.containerSecurityContext | object | `{}` |  |
+| worker.debug.enabled | bool | `false` |  |
+| worker.debug.remoteDebugPort | string | `nil` |  |
 | worker.enabled | bool | `true` |  |
 | worker.extraContainers | list | `[]` |  |
 | worker.extraEnv | list | `[]` |  |

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -217,6 +217,7 @@ webapp:
     successThreshold: 1
 
   ##  webapp.readinessProbe.enabled Enable readinessProbe on the webapp
+  ##  webapp.readinessProbe.httpPath HTTP path used for readinessProbe
   ##  webapp.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ##  webapp.readinessProbe.periodSeconds Period seconds for readinessProbe
   ##  webapp.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -225,6 +226,7 @@ webapp:
   ##
   readinessProbe:
     enabled: true
+    httpPath: "/api/v1/health"
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 1

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -544,6 +544,7 @@ server:
   ## Configure extra options for the server containers' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ##  server.livenessProbe.enabled Enable livenessProbe on the server
+  ##  server.livenessProbe.httpPath HTTP Path used by for livenessProbe
   ##  server.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ##  server.livenessProbe.periodSeconds Period seconds for livenessProbe
   ##  server.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -552,6 +553,7 @@ server:
   ##
   livenessProbe:
     enabled: true
+    httpPath: "/api/v1/health"
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 1
@@ -559,6 +561,7 @@ server:
     successThreshold: 1
 
   ##  server.readinessProbe.enabled Enable readinessProbe on the server
+  ##  server.readinessProbe.httpPath HTTP Path used by for readinessProbe
   ##  server.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ##  server.readinessProbe.periodSeconds Period seconds for readinessProbe
   ##  server.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -567,6 +570,7 @@ server:
   ##
   readinessProbe:
     enabled: true
+    httpPath: "/api/v1/health"
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 1


### PR DESCRIPTION
## What

Liveness and readiness checks should not check downstream dependencies because momentary hiccups can take the whole service out and prolong down time. 

See 
- [leank8s/kubernetes-production-best-practices](https://github.com/learnk8s/kubernetes-production-best-practices/blob/master/application-development.md#apps-are-independent)
- [kube-score](https://github.com/zegl/kube-score/blob/master/README_PROBES.md)

## How

Add separate webapp and server api paths to be used specifically for liveness/readiness probes and update
the helm chart to use them instead.

The key features are:

1. They do not have any dependencies on downstream services - they are completely independent
2. They are separate - readiness and liveness probes are different endpoints; allowing some logic to be added in the future if they should behave differently.

In a more robust system, the readiness probe should fail once the application receives a SIGTERM; but the liveness check should remain OK. This will take the pod out of the service, while allowing connections to drain and work to complete as the application shuts itself down. Currently this is not implemented.

### airbyte-webapp

- add `/.well-known/readyz` endpoint that returns 200 OK
- use this endpoint in webapp helm chart in place of /api/v1/health (which checks api + db)

### airbyte-server

- add `/health/readiness` and `/health/liveness` endpoints that return 200 OK (via Micronaut's [HealthIndicators / Endpoint](https://docs.micronaut.io/latest/guide/#healthEndpoint))
- use these endpoints in server helm chart 

## Recommended reading order

1. `airbyte-webapp/nginx/default.conf.template`
2. `charts/airbyte-webapp/templates/deployment.yaml`
3. `airbyte-server/src/main/resources/application.yml`
4. `airbyte-server/src/main/java/io/airbyte/server/LivenessIndicator.java`
5. `airbyte-server/src/main/java/io/airbyte/server/ReadinessIndicator.java`
6. `charts/airbyte-server/templates/deployment.yaml`


## Can this PR be safely reverted / rolled back?
- [x] YES 💚

## 🚨 User Impact 🚨

End result might change the behavior if the user was previously relying on the health checks hitting the database and causing a restart/outage on the server + webapp.
