### PR TITLE
fix(worker): ConnectionManagerWorkflowImpl null connectionId

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -82,6 +82,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -137,6 +138,9 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   @Trace(operationName = WORKFLOW_TRACE_OPERATION_NAME)
   @Override
   public void run(final ConnectionUpdaterInput connectionUpdaterInput) throws RetryableException {
+    if (connectionId == null) {
+      connectionId = Objects.requireNonNull(connectionUpdaterInput.getConnectionId());
+    }
     try {
       ApmTraceUtils.addTagsToTrace(Map.of(CONNECTION_ID_KEY, connectionUpdaterInput.getConnectionId()));
 


### PR DESCRIPTION
## What

The issue is happening using 0.44.1 or 0.44.2 version

An invariant of the ConnectionManagerWorkflow objects is violated when the class is constructed by the runtime; namely the connectionId value is null when it is expected to always be non-null.

```
2023-04-20 18:09:33 ERROR i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):595 - [ACTIVITY-FAILURE] Connection null failed to run an activity.(RecordMetricInput).  Connection manager workflow will be restarted after a delay of PT10M.
io.temporal.failure.ActivityFailure: scheduledEventId=11, startedEventId=12, activityType='RecordWorkflowCountMetric', activityId='b2789fb5-8cde-31b2-a5f9-94a2119e734a', identity='', retryState=RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
	at java.lang.Thread.getStackTrace(Thread.java:2550) ~[?:?]
	at io.temporal.internal.sync.ActivityStubBase.execute(ActivityStubBase.java:49) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.ActivityInvocationHandler.lambda$getActivityFunc$0(ActivityInvocationHandler.java:78) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.ActivityInvocationHandlerBase.invoke(ActivityInvocationHandlerBase.java:60) ~[temporal-sdk-1.17.0.jar:?]
	at jdk.proxy2.$Proxy93.recordWorkflowCountMetric(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.lambda$runMandatoryActivity$2(ConnectionManagerWorkflowImpl.java:645) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivityWithOutput(ConnectionManagerWorkflowImpl.java:593) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivity(ConnectionManagerWorkflowImpl.java:644) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.recordMetric(ConnectionManagerWorkflowImpl.java:679) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.run(ConnectionManagerWorkflowImpl.java:147) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at ConnectionManagerWorkflowImplProxy.run$accessor$tSBG1ZQP(Unknown Source) ~[?:?]
	at ConnectionManagerWorkflowImplProxy$auxiliary$kVeHdgrW.call(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.support.TemporalActivityStubInterceptor.execute(TemporalActivityStubInterceptor.java:79) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at ConnectionManagerWorkflowImplProxy.run(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:302) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:277) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:71) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:116) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:106) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.worker.ActiveThreadReportingExecutor.lambda$submit$0(ActiveThreadReportingExecutor.java:53) ~[temporal-sdk-1.17.0.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
Caused by: io.temporal.failure.TimeoutFailure: message='activity timeout', timeoutType=TIMEOUT_TYPE_HEARTBEAT
Caused by: io.temporal.failure.TimeoutFailure: message='activity timeout', timeoutType=TIMEOUT_TYPE_HEARTBEAT
2023-04-20 18:09:33 INFO i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):604 - Waiting PT10M before restarting the workflow for connection null, to prevent spamming temporal with restarts.
2023-04-20 18:09:33 ERROR i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):595 - [ACTIVITY-FAILURE] Connection null failed to run an activity.(RecordMetricInput).  Connection manager workflow will be restarted after a delay of PT10M.
io.temporal.failure.ActivityFailure: scheduledEventId=11, startedEventId=12, activityType='RecordWorkflowCountMetric', activityId='1c37ae0d-7cd6-3ce5-80b6-6e2e7b4646c4', identity='', retryState=RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
	at java.lang.Thread.getStackTrace(Thread.java:2550) ~[?:?]
	at io.temporal.internal.sync.ActivityStubBase.execute(ActivityStubBase.java:49) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.ActivityInvocationHandler.lambda$getActivityFunc$0(ActivityInvocationHandler.java:78) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.ActivityInvocationHandlerBase.invoke(ActivityInvocationHandlerBase.java:60) ~[temporal-sdk-1.17.0.jar:?]
	at jdk.proxy2.$Proxy93.recordWorkflowCountMetric(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.lambda$runMandatoryActivity$2(ConnectionManagerWorkflowImpl.java:645) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivityWithOutput(ConnectionManagerWorkflowImpl.java:593) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivity(ConnectionManagerWorkflowImpl.java:644) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.recordMetric(ConnectionManagerWorkflowImpl.java:679) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.run(ConnectionManagerWorkflowImpl.java:147) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at ConnectionManagerWorkflowImplProxy.run$accessor$tSBG1ZQP(Unknown Source) ~[?:?]
	at ConnectionManagerWorkflowImplProxy$auxiliary$kVeHdgrW.call(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.support.TemporalActivityStubInterceptor.execute(TemporalActivityStubInterceptor.java:79) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at ConnectionManagerWorkflowImplProxy.run(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:302) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:277) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:71) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:116) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:106) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.worker.ActiveThreadReportingExecutor.lambda$submit$0(ActiveThreadReportingExecutor.java:53) ~[temporal-sdk-1.17.0.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
Caused by: io.temporal.failure.TimeoutFailure: message='activity timeout', timeoutType=TIMEOUT_TYPE_HEARTBEAT
Caused by: io.temporal.failure.TimeoutFailure: message='activity timeout', timeoutType=TIMEOUT_TYPE_HEARTBEAT
2023-04-20 18:09:33 INFO i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):604 - Waiting PT10M before restarting the workflow for connection null, to prevent spamming temporal with restarts.
2023-04-20 18:09:33 INFO i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):619 - Finished wait for connection null, restarting connection manager workflow
2023-04-20 18:09:33 ERROR i.a.w.t.s.ConnectionManagerWorkflowImpl(run):181 - The connection update workflow has failed, will create a new attempt.
java.lang.NullPointerException: connectionId is marked non-null but is null
	at io.airbyte.commons.temporal.scheduling.ConnectionUpdaterInput$ConnectionUpdaterInputBuilder.connectionId(ConnectionUpdaterInput.java:23) ~[io.airbyte-airbyte-commons-temporal-dev.jar:?]
	at io.airbyte.commons.temporal.TemporalWorkflowUtils.buildStartWorkflowInput(TemporalWorkflowUtils.java:39) ~[io.airbyte-airbyte-commons-temporal-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivityWithOutput(ConnectionManagerWorkflowImpl.java:621) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivity(ConnectionManagerWorkflowImpl.java:644) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.recordMetric(ConnectionManagerWorkflowImpl.java:679) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.run(ConnectionManagerWorkflowImpl.java:147) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at ConnectionManagerWorkflowImplProxy.run$accessor$tSBG1ZQP(Unknown Source) ~[?:?]
	at ConnectionManagerWorkflowImplProxy$auxiliary$kVeHdgrW.call(Unknown Source) ~[?:?]
	at io.airbyte.workers.temporal.support.TemporalActivityStubInterceptor.execute(TemporalActivityStubInterceptor.java:79) ~[io.airbyte-airbyte-workers-dev.jar:?]
	at ConnectionManagerWorkflowImplProxy.run(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:302) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:277) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:71) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:116) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:106) ~[temporal-sdk-1.17.0.jar:?]
	at io.temporal.worker.ActiveThreadReportingExecutor.lambda$submit$0(ActiveThreadReportingExecutor.java:53) ~[temporal-sdk-1.17.0.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
2023-04-20 18:09:33 INFO i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):619 - Finished wait for connection null, restarting connection manager workflow
```

Could be related to airbytehq/airbyte#20014

## How

This change detects a null connectionId in ConnectionManagerWorkflowImpl::run and will set it to connectionUpdaterInput.getConnectionId() which is guaranteed not to be null.

After adding this change, i got the following log message to indicate this code was executed.

```
2023-04-20 20:40:30 WARN i.a.w.t.s.ConnectionManagerWorkflowImpl(run):142 - connectionId is null for workflow 015eacb1-a9c2-455d-83f6-64d9ae0ffc46; setting to input connection 1b31343b-6606-4065-86bb-7f3cfd5019af
```

I no longer got NPEs going forward.

## Recommended reading order
1. `airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java`

## Can this PR be safely reverted / rolled back?

- [x] YES 💚


## 🚨 User Impact 🚨
N/A
