### PR TITLE
feat(helm): allow job images to be overwritten

### DIFF
--- a/charts/airbyte-bootloader/README.md
+++ b/charts/airbyte-bootloader/README.md
@@ -1,6 +1,6 @@
 # airbyte-bootloader
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-bootloader
 
@@ -15,18 +15,25 @@ Helm chart to deploy airbyte-bootloader
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| containerSecurityContext | object | `{}` |  |
 | enabled | bool | `true` |  |
 | env_vars | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
+| global.database.host | string | `"example.com"` |  |
+| global.database.port | string | `"5432"` |  |
 | global.database.secretName | string | `""` |  |
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.env_vars | object | `{}` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.secrets | object | `{}` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
@@ -34,6 +41,7 @@ Helm chart to deploy airbyte-bootloader
 | image.repository | string | `"airbyte/bootloader"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
 | secrets | object | `{}` |  |

--- a/charts/airbyte-connector-builder-server/README.md
+++ b/charts/airbyte-connector-builder-server/README.md
@@ -1,8 +1,8 @@
-# server
+# connector-builder-server
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
-Helm chart to deploy airbyte-server
+Helm chart to deploy airbyte-connector-builder-server
 
 ## Requirements
 
@@ -31,26 +31,12 @@ Helm chart to deploy airbyte-server
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
-| global.logs.accessKey.existingSecret | string | `""` |  |
-| global.logs.accessKey.existingSecretKey | string | `""` |  |
-| global.logs.accessKey.password | string | `"minio"` |  |
-| global.logs.externalMinio.enabled | bool | `false` |  |
-| global.logs.externalMinio.host | string | `"localhost"` |  |
-| global.logs.externalMinio.port | int | `9000` |  |
-| global.logs.gcs.bucket | string | `""` |  |
-| global.logs.gcs.credentials | string | `""` |  |
-| global.logs.gcs.credentialsJson | string | `""` |  |
-| global.logs.minio.enabled | bool | `true` |  |
-| global.logs.s3.bucket | string | `"airbyte-dev-logs"` |  |
-| global.logs.s3.bucketRegion | string | `""` |  |
-| global.logs.s3.enabled | bool | `false` |  |
-| global.logs.secretKey.existingSecret | string | `""` |  |
-| global.logs.secretKey.existingSecretKey | string | `""` |  |
-| global.logs.secretKey.password | string | `"minio123"` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"airbyte/server"` |  |
+| image.repository | string | `"airbyte/connector-atelier-server"` |  |
 | livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.initialDelaySeconds | int | `30` |  |
@@ -71,8 +57,8 @@ Helm chart to deploy airbyte-server
 | resources.requests | object | `{}` |  |
 | secrets | object | `{}` |  |
 | service.annotations | object | `{}` |  |
-| service.port | int | `8001` |  |
-| service.type | string | `"ClusterIP"` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"NodePort"` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/airbyte-cron/README.md
+++ b/charts/airbyte-cron/README.md
@@ -1,6 +1,6 @@
-# airbyte-cron
+# cron
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.17](https://img.shields.io/badge/AppVersion-0.40.17-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-cron
 
@@ -21,6 +21,8 @@ Helm chart to deploy airbyte-cron
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.configMapName | string | `""` |  |
@@ -30,7 +32,10 @@ Helm chart to deploy airbyte-cron
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
+| global.secrets | object | `{}` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"airbyte/cron"` |  |
@@ -42,6 +47,7 @@ Helm chart to deploy airbyte-cron
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.containerSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |

--- a/charts/airbyte-metrics/README.md
+++ b/charts/airbyte-metrics/README.md
@@ -1,6 +1,6 @@
 # metrics
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.3](https://img.shields.io/badge/AppVersion-0.40.3-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.3](https://img.shields.io/badge/AppVersion-0.40.3-informational?style=flat-square)
 
 Helm chart to deploy airbyte-metrics
 
@@ -33,6 +33,7 @@ Helm chart to deploy airbyte-metrics
 | image.repository | string | `"airbyte/metrics-reporter"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |

--- a/charts/airbyte-pod-sweeper/README.md
+++ b/charts/airbyte-pod-sweeper/README.md
@@ -1,6 +1,6 @@
 # pod-sweeper
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.37-alpha](https://img.shields.io/badge/AppVersion-0.39.37--alpha-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.37-alpha](https://img.shields.io/badge/AppVersion-0.39.37--alpha-informational?style=flat-square)
 
 Helm chart to deploy airbyte-pod-sweeper
 
@@ -56,16 +56,21 @@ Helm chart to deploy airbyte-pod-sweeper
 | livenessProbe.periodSeconds | int | `30` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `1` |  |
+| namespace | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
 | readinessProbe.periodSeconds | int | `30` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
+| timeToDeletePods.completed | int | `120` |  |
+| timeToDeletePods.error | int | `1440` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/airbyte-server/README.md
+++ b/charts/airbyte-server/README.md
@@ -1,6 +1,6 @@
 # server
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-server
 
@@ -16,11 +16,14 @@ Helm chart to deploy airbyte-server
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | containerSecurityContext | object | `{}` |  |
+| deploymentStrategyType | string | `"Recreate"` |  |
 | enabled | bool | `true` |  |
 | env_vars | object | `{}` |  |
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.configMapName | string | `""` |  |
@@ -31,6 +34,8 @@ Helm chart to deploy airbyte-server
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.logs.accessKey.existingSecret | string | `""` |  |
 | global.logs.accessKey.existingSecretKey | string | `""` |  |
 | global.logs.accessKey.password | string | `"minio"` |  |
@@ -60,6 +65,7 @@ Helm chart to deploy airbyte-server
 | log.level | string | `"INFO"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |

--- a/charts/airbyte-temporal/README.md
+++ b/charts/airbyte-temporal/README.md
@@ -1,6 +1,6 @@
 # temporal
 
-![Version: 0.40.33](https://img.shields.io/badge/Version-0.40.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.17](https://img.shields.io/badge/AppVersion-0.40.17-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-temporal
 
@@ -21,6 +21,8 @@ Helm chart to deploy airbyte-temporal
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.configMapName | string | `""` |  |
@@ -30,6 +32,8 @@ Helm chart to deploy airbyte-temporal
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -43,6 +47,7 @@ Helm chart to deploy airbyte-temporal
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |

--- a/charts/airbyte-webapp/README.md
+++ b/charts/airbyte-webapp/README.md
@@ -1,6 +1,6 @@
 # webapp
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-webapp
 
@@ -22,6 +22,8 @@ Helm chart to deploy airbyte-webapp
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | fullstory.enabled | bool | `false` |  |
@@ -32,6 +34,8 @@ Helm chart to deploy airbyte-webapp
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.secretName | string | `""` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -49,6 +53,7 @@ Helm chart to deploy airbyte-webapp
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |

--- a/charts/airbyte-worker/README.md
+++ b/charts/airbyte-worker/README.md
@@ -1,6 +1,6 @@
 # worker
 
-![Version: 0.39.36](https://img.shields.io/badge/Version-0.39.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.4](https://img.shields.io/badge/AppVersion-0.40.4-informational?style=flat-square)
+![Version: 0.44.7](https://img.shields.io/badge/Version-0.44.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-worker
 
@@ -21,6 +21,8 @@ Helm chart to deploy airbyte-worker
 | extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| extraSelectorLabels | object | `{}` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | global.credVolumeOverride | string | `""` |  |
@@ -29,7 +31,12 @@ Helm chart to deploy airbyte-worker
 | global.database.secretName | string | `""` |  |
 | global.database.secretValue | string | `""` |  |
 | global.extraContainers | list | `[]` |  |
+| global.extraLabels | object | `{}` |  |
+| global.extraSelectorLabels | object | `{}` |  |
 | global.jobs.kube.annotations | object | `{}` |  |
+| global.jobs.kube.images.busybox | string | `""` |  |
+| global.jobs.kube.images.curl | string | `""` |  |
+| global.jobs.kube.images.socat | string | `""` |  |
 | global.jobs.kube.main_container_image_pull_secret | string | `""` |  |
 | global.jobs.kube.nodeSelector | object | `{}` |  |
 | global.jobs.kube.tolerations | list | `[]` |  |
@@ -64,6 +71,7 @@ Helm chart to deploy airbyte-worker
 | log.level | string | `"INFO"` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.initialDelaySeconds | int | `10` |  |

--- a/charts/airbyte-worker/README.md
+++ b/charts/airbyte-worker/README.md
@@ -1,6 +1,6 @@
 # worker
 
-![Version: 0.44.7](https://img.shields.io/badge/Version-0.44.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte-worker
 

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -152,6 +152,27 @@ spec:
               name: {{ .Release.Name }}-airbyte-env
               key: JOB_KUBE_TOLERATIONS
         {{- end }}
+        {{- if $.Values.global.jobs.kube.images.busybox }}
+        - name: JOB_KUBE_BUSYBOX_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: JOB_KUBE_BUSYBOX_IMAGE
+        {{- end }}
+        {{- if $.Values.global.jobs.kube.images.socat }}
+        - name: JOB_KUBE_SOCAT_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: JOB_KUBE_SOCAT_IMAGE
+        {{- end }}
+        {{- if $.Values.global.jobs.kube.images.curl }}
+        - name: JOB_KUBE_CURL_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: JOB_KUBE_CURL_IMAGE
+        {{- end }}
         {{- if $.Values.global.jobs.kube.main_container_image_pull_secret }}
         - name: JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET
           valueFrom:

--- a/charts/airbyte-worker/values.yaml
+++ b/charts/airbyte-worker/values.yaml
@@ -107,6 +107,19 @@ global:
       ##  jobs.kube.main_container_image_pull_secret [string]  image pull secret to use for job pod
       main_container_image_pull_secret: ""
 
+      images:
+        ## JOB_KUBE_BUSYBOX_IMAGE
+        ## busybox image used by the job pod
+        ##   jobs.kube.images.busybox [string] busybox image used by the job pod
+        busybox: ""
+        ## JOB_KUBE_SOCAT_IMAGE
+        ## socat image used by the job pod
+        ##   jobs.kube.images.socat [string] socat image used by the job pod
+        socat: ""
+        ## JOB_KUBE_CURL_IMAGE
+        ## curl image used by the job pod
+        ##   jobs.kube.images.curl [string] curl image used by the job pod
+        curl: ""
 
 enabled: true
 ##  worker.replicaCount Number of worker replicas

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -96,6 +96,9 @@ Helm chart to deploy airbyte
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.jobs.kube.annotations | object | `{}` |  |
+| global.jobs.kube.images.busybox | string | `""` |  |
+| global.jobs.kube.images.curl | string | `""` |  |
+| global.jobs.kube.images.socat | string | `""` |  |
 | global.jobs.kube.main_container_image_pull_secret | string | `""` |  |
 | global.jobs.kube.nodeSelector | object | `{}` |  |
 | global.jobs.kube.tolerations | list | `[]` |  |

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -1,6 +1,6 @@
 # airbyte
 
-![Version: 0.44.8](https://img.shields.io/badge/Version-0.44.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
+![Version: 0.45.12](https://img.shields.io/badge/Version-0.45.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.44.2](https://img.shields.io/badge/AppVersion-0.44.2-informational?style=flat-square)
 
 Helm chart to deploy airbyte
 
@@ -8,15 +8,15 @@ Helm chart to deploy airbyte
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://airbytehq.github.io/helm-charts/ | airbyte-bootloader | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | connector-builder-server | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | cron | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | metrics | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | pod-sweeper | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | server | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | temporal | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | webapp | 0.44.7 |
-| https://airbytehq.github.io/helm-charts/ | worker | 0.44.7 |
+| https://airbytehq.github.io/helm-charts/ | airbyte-bootloader | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | connector-builder-server | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | cron | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | metrics | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | pod-sweeper | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | server | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | temporal | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | webapp | 0.45.12 |
+| https://airbytehq.github.io/helm-charts/ | worker | 0.45.12 |
 | https://charts.bitnami.com/bitnami | common | 1.x.x |
 
 ## Values

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -33,6 +33,15 @@ data:
 {{- if $.Values.global.jobs.kube.tolerations }}
   JOB_KUBE_TOLERATIONS: {{ $.Values.global.jobs.kube.tolerations | include "airbyte.flattenArrayMap" | quote }}
 {{- end }}
+{{- if $.Values.global.jobs.kube.images.busybox }}
+  JOB_KUBE_BUSYBOX_IMAGE: {{ $.Values.global.jobs.kube.images.busybox | quote }}
+{{- end }}
+{{- if $.Values.global.jobs.kube.images.socat }}
+  JOB_KUBE_SOCAT_IMAGE: {{ $.Values.global.jobs.kube.images.socat | quote }}
+{{- end }}
+{{- if $.Values.global.jobs.kube.images.curl }}
+  JOB_KUBE_CURL_IMAGE: {{ $.Values.global.jobs.kube.images.curl | quote }}
+{{- end }}
   JOB_MAIN_CONTAINER_CPU_LIMIT: {{ ((.Values.global.jobs.resources | default dict).limits | default dict).cpu | default "" | quote }}
   JOB_MAIN_CONTAINER_CPU_REQUEST: {{ ((.Values.global.jobs.resources | default dict).requests | default dict).cpu | default "" | quote }}
   JOB_MAIN_CONTAINER_MEMORY_LIMIT: {{ ((.Values.global.jobs.resources | default dict).limits | default dict).memory | default "" | quote }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -130,6 +130,20 @@ global:
       ##  jobs.kube.main_container_image_pull_secret [string]  image pull secret to use for job pod
       main_container_image_pull_secret: ""
 
+      images:
+        ## JOB_KUBE_BUSYBOX_IMAGE
+        ## busybox image used by the job pod
+        ##   jobs.kube.images.busybox [string] busybox image used by the job pod
+        busybox: ""
+        ## JOB_KUBE_SOCAT_IMAGE
+        ## socat image used by the job pod
+        ##   jobs.kube.images.socat [string] socat image used by the job pod
+        socat: ""
+        ## JOB_KUBE_CURL_IMAGE
+        ## curl image used by the job pod
+        ##   jobs.kube.images.curl [string] curl image used by the job pod
+        curl: ""
+
 ## @section Common Parameters
 
 ##  nameOverride -- String to partially override airbyte.fullname template with a string (will prepend the release name)

--- a/charts/airbyte/values.yaml.test
+++ b/charts/airbyte/values.yaml.test
@@ -132,6 +132,20 @@ global:
       ##  jobs.kube.main_container_image_pull_secret [string]  image pull secret to use for job pod
       main_container_image_pull_secret: ""
 
+      images:
+        ## JOB_KUBE_BUSYBOX_IMAGE
+        ## busybox image used by the job pod
+        ##   jobs.kube.images.busybox [string] busybox image used by the job pod
+        busybox: ""
+        ## JOB_KUBE_SOCAT_IMAGE
+        ## socat image used by the job pod
+        ##   jobs.kube.images.socat [string] socat image used by the job pod
+        socat: ""
+        ## JOB_KUBE_CURL_IMAGE
+        ## curl image used by the job pod
+        ##   jobs.kube.images.curl [string] curl image used by the job pod
+        curl: ""
+
 ## @section Common Parameters
 
 ##  nameOverride -- String to partially override airbyte.fullname template with a string (will prepend the release name)


### PR DESCRIPTION
## What

The worker process supports overriding the images used by the kubernetes jobs; however
the helm chart so far has not had the direct ability to override values, so the defaults are always used.

This is a problem since docker hub rate limits access to public images, and it can cause an outage if those rate limits are tripped.  

```
Warning  Failed     10m (x4 over 12m)     kubelet            Failed to pull image "busybox:1.28": rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/busybox:1.28": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/busybox/manifests/sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
 ```

The solution is to have a local mirror or to use another public source that doesn't have rate limits.

## How

Creates a new set of values for overriding the images that are used by the worker jobs:
  - global.jobs.kube.images.busybox
  - global.jobs.kube.images.socat
  - global.jobs.kube.images.curl

*Note* : This PR is not strictly necessary to solve the issue. You can pass the values as extra environment variables; its just less discoverable without these options; implying that this as a niche concern. In reality, the docker hub rate limits are such that anyone using Airbyte at some non trivial scale will run into this issue and likely should mirror these images in their local registries and use them instead of the public ones.

```
worker:
  extraEnv:
    - name: JOB_KUBE_SOCAT_IMAGE
      value: xxxxxxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/alpine/socat:1.7.4.3-r0
    - name: JOB_KUBE_BUSYBOX_IMAGE
      value: xxxxxxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/library/busybox:1.28
    - name: JOB_KUBE_CURL_IMAGE
      value: xxxxxxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/curlimages/curl:7.83.1
    - name: AWS_ACCESS_KEY_ID
```

## Recommended reading order
1. `charts/airbyte-worker/values.yaml`
2. `charts/airbyte-worker/templates/deployment.yaml`
3. `charts/airbyte/values.yaml.test`
4. `charts/airbyte/templates/env-configmap.yaml`

## Can this PR be safely reverted / rolled back?
- [ ] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
As this is a new feature, there should be no backwards incompatibility
