### PR TITLE
fix(kubernetes): Exceptions in new KubePodProcess(...) can leak resou…

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -417,219 +417,225 @@ public class KubePodProcess implements KubePod {
                         final Map<Integer, Integer> internalToExternalPorts,
                         final String... args)
       throws IOException, InterruptedException {
-    this.fabricClient = fabricClient;
-    this.stdoutLocalPort = stdoutLocalPort;
-    this.stderrLocalPort = stderrLocalPort;
-    this.stdoutServerSocket = new ServerSocket(stdoutLocalPort);
-    this.stderrServerSocket = new ServerSocket(stderrLocalPort);
-    this.executorService = Executors.newFixedThreadPool(2);
-    setupStdOutAndStdErrListeners();
+    try {
+      this.fabricClient = fabricClient;
+      this.stdoutLocalPort = stdoutLocalPort;
+      this.stderrLocalPort = stderrLocalPort;
+      this.stdoutServerSocket = new ServerSocket(stdoutLocalPort);
+      this.stderrServerSocket = new ServerSocket(stderrLocalPort);
+      this.executorService = Executors.newFixedThreadPool(2);
+      setupStdOutAndStdErrListeners();
 
-    if (entrypointOverride != null) {
-      LOGGER.info("Found entrypoint override: {}", entrypointOverride);
-    }
+      if (entrypointOverride != null) {
+        LOGGER.info("Found entrypoint override: {}", entrypointOverride);
+      }
 
-    final Volume pipeVolume = new VolumeBuilder()
-        .withName("airbyte-pipes")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
+      final Volume pipeVolume = new VolumeBuilder()
+          .withName("airbyte-pipes")
+          .withNewEmptyDir()
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount pipeVolumeMount = new VolumeMountBuilder()
-        .withName("airbyte-pipes")
-        .withMountPath(PIPES_DIR)
-        .build();
+      final VolumeMount pipeVolumeMount = new VolumeMountBuilder()
+          .withName("airbyte-pipes")
+          .withMountPath(PIPES_DIR)
+          .build();
 
-    final Volume configVolume = new VolumeBuilder()
-        .withName("airbyte-config")
-        .withNewEmptyDir()
-        .withMedium("Memory")
-        .endEmptyDir()
-        .build();
+      final Volume configVolume = new VolumeBuilder()
+          .withName("airbyte-config")
+          .withNewEmptyDir()
+          .withMedium("Memory")
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount configVolumeMount = new VolumeMountBuilder()
-        .withName("airbyte-config")
-        .withMountPath(CONFIG_DIR)
-        .build();
+      final VolumeMount configVolumeMount = new VolumeMountBuilder()
+          .withName("airbyte-config")
+          .withMountPath(CONFIG_DIR)
+          .build();
 
-    final Volume terminationVolume = new VolumeBuilder()
-        .withName("airbyte-termination")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
+      final Volume terminationVolume = new VolumeBuilder()
+          .withName("airbyte-termination")
+          .withNewEmptyDir()
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount terminationVolumeMount = new VolumeMountBuilder()
-        .withName("airbyte-termination")
-        .withMountPath(TERMINATION_DIR)
-        .build();
+      final VolumeMount terminationVolumeMount = new VolumeMountBuilder()
+          .withName("airbyte-termination")
+          .withMountPath(TERMINATION_DIR)
+          .build();
 
-    final Volume tmpVolume = new VolumeBuilder()
-        .withName("tmp")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
+      final Volume tmpVolume = new VolumeBuilder()
+          .withName("tmp")
+          .withNewEmptyDir()
+          .endEmptyDir()
+          .build();
 
-    final VolumeMount tmpVolumeMount = new VolumeMountBuilder()
-        .withName("tmp")
-        .withMountPath(TMP_DIR)
-        .build();
+      final VolumeMount tmpVolumeMount = new VolumeMountBuilder()
+          .withName("tmp")
+          .withMountPath(TMP_DIR)
+          .build();
 
-    final Container init = getInit(usesStdin, List.of(pipeVolumeMount, configVolumeMount), busyboxImage);
-    final Container main = getMain(
-        image,
-        imagePullPolicy,
-        usesStdin,
-        entrypointOverride,
-        List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount, tmpVolumeMount),
-        resourceRequirements,
-        internalToExternalPorts,
-        envMap,
-        args);
+      final Container init = getInit(usesStdin, List.of(pipeVolumeMount, configVolumeMount), busyboxImage);
+      final Container main = getMain(
+          image,
+          imagePullPolicy,
+          usesStdin,
+          entrypointOverride,
+          List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount, tmpVolumeMount),
+          resourceRequirements,
+          internalToExternalPorts,
+          envMap,
+          args);
 
-    // Printing socat notice logs with socat -d -d
-    // To print info logs as well use socat -d -d -d
-    // more info: https://linux.die.net/man/1/socat
-    final io.fabric8.kubernetes.api.model.ResourceRequirements heartbeatSidecarResources =
-        getResourceRequirementsBuilder(DEFAULT_SIDECAR_RESOURCES).build();
-    final io.fabric8.kubernetes.api.model.ResourceRequirements socatSidecarResources =
-        getResourceRequirementsBuilder(DEFAULT_SOCAT_RESOURCES).build();
+      // Printing socat notice logs with socat -d -d
+      // To print info logs as well use socat -d -d -d
+      // more info: https://linux.die.net/man/1/socat
+      final io.fabric8.kubernetes.api.model.ResourceRequirements heartbeatSidecarResources =
+          getResourceRequirementsBuilder(DEFAULT_SIDECAR_RESOURCES).build();
+      final io.fabric8.kubernetes.api.model.ResourceRequirements socatSidecarResources =
+          getResourceRequirementsBuilder(DEFAULT_SOCAT_RESOURCES).build();
 
-    final Container remoteStdin = new ContainerBuilder()
-        .withName("remote-stdin")
-        .withImage(socatImage)
-        .withCommand("sh", "-c", "socat -d -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
-        .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
-        .withResources(socatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container remoteStdin = new ContainerBuilder()
+          .withName("remote-stdin")
+          .withImage(socatImage)
+          .withCommand("sh", "-c", "socat -d -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
+          .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
+          .withResources(socatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    final Container relayStdout = new ContainerBuilder()
-        .withName("relay-stdout")
-        .withImage(socatImage)
-        .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
-        .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
-        .withResources(socatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container relayStdout = new ContainerBuilder()
+          .withName("relay-stdout")
+          .withImage(socatImage)
+          .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
+          .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
+          .withResources(socatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    final Container relayStderr = new ContainerBuilder()
-        .withName("relay-stderr")
-        .withImage(socatImage)
-        .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
-        .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
-        .withResources(socatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container relayStderr = new ContainerBuilder()
+          .withName("relay-stderr")
+          .withImage(socatImage)
+          .withCommand("sh", "-c", String.format("cat %s | socat -d -d -t 60 - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
+          .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
+          .withResources(socatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    // communicates via a file if it isn't able to reach the heartbeating server and succeeds if the
-    // main container completes
-    final String heartbeatCommand = MoreResources.readResource("entrypoints/sync/check.sh")
-        .replaceAll("TERMINATION_FILE_CHECK", TERMINATION_FILE_CHECK)
-        .replaceAll("TERMINATION_FILE_MAIN", TERMINATION_FILE_MAIN)
-        .replaceAll("HEARTBEAT_URL", kubeHeartbeatUrl);
+      // communicates via a file if it isn't able to reach the heartbeating server and succeeds if the
+      // main container completes
+      final String heartbeatCommand = MoreResources.readResource("entrypoints/sync/check.sh")
+          .replaceAll("TERMINATION_FILE_CHECK", TERMINATION_FILE_CHECK)
+          .replaceAll("TERMINATION_FILE_MAIN", TERMINATION_FILE_MAIN)
+          .replaceAll("HEARTBEAT_URL", kubeHeartbeatUrl);
 
-    final Container callHeartbeatServer = new ContainerBuilder()
-        .withName("call-heartbeat-server")
-        .withImage(curlImage)
-        .withCommand("sh")
-        .withArgs("-c", heartbeatCommand)
-        .withVolumeMounts(terminationVolumeMount)
-        .withResources(heartbeatSidecarResources)
-        .withImagePullPolicy(sidecarImagePullPolicy)
-        .build();
+      final Container callHeartbeatServer = new ContainerBuilder()
+          .withName("call-heartbeat-server")
+          .withImage(curlImage)
+          .withCommand("sh")
+          .withArgs("-c", heartbeatCommand)
+          .withVolumeMounts(terminationVolumeMount)
+          .withResources(heartbeatSidecarResources)
+          .withImagePullPolicy(sidecarImagePullPolicy)
+          .build();
 
-    final List<Container> containers = usesStdin ? List.of(main, remoteStdin, relayStdout, relayStderr, callHeartbeatServer)
-        : List.of(main, relayStdout, relayStderr, callHeartbeatServer);
+      final List<Container> containers = usesStdin ? List.of(main, remoteStdin, relayStdout, relayStderr, callHeartbeatServer)
+          : List.of(main, relayStdout, relayStderr, callHeartbeatServer);
 
-    PodFluent.SpecNested<PodBuilder> podBuilder = new PodBuilder()
-        .withApiVersion("v1")
-        .withNewMetadata()
-        .withName(podName)
-        .withLabels(labels)
-        .withAnnotations(annotations)
-        .endMetadata()
-        .withNewSpec();
+      PodFluent.SpecNested<PodBuilder> podBuilder = new PodBuilder()
+          .withApiVersion("v1")
+          .withNewMetadata()
+          .withName(podName)
+          .withLabels(labels)
+          .withAnnotations(annotations)
+          .endMetadata()
+          .withNewSpec();
 
-    if (isOrchestrator) {
-      podBuilder = podBuilder.withServiceAccount("airbyte-admin").withAutomountServiceAccountToken(true);
-    }
+      if (isOrchestrator) {
+        podBuilder = podBuilder.withServiceAccount("airbyte-admin").withAutomountServiceAccountToken(true);
+      }
 
-    final List<LocalObjectReference> pullSecrets = imagePullSecrets
-        .stream()
-        .map(imagePullSecret -> new LocalObjectReference(imagePullSecret))
-        .collect(Collectors.toList());
+      final List<LocalObjectReference> pullSecrets = imagePullSecrets
+          .stream()
+          .map(imagePullSecret -> new LocalObjectReference(imagePullSecret))
+          .collect(Collectors.toList());
 
-    final Pod pod = podBuilder.withTolerations(buildPodTolerations(tolerations))
-        .withImagePullSecrets(pullSecrets) // An empty list or an empty LocalObjectReference turns this into a no-op setting.
-        .withNodeSelector(nodeSelectors)
-        .withRestartPolicy("Never")
-        .withInitContainers(init)
-        .withContainers(containers)
-        .withVolumes(pipeVolume, configVolume, terminationVolume, tmpVolume)
-        .endSpec()
-        .build();
+      final Pod pod = podBuilder.withTolerations(buildPodTolerations(tolerations))
+          .withImagePullSecrets(pullSecrets) // An empty list or an empty LocalObjectReference turns this into a no-op setting.
+          .withNodeSelector(nodeSelectors)
+          .withRestartPolicy("Never")
+          .withInitContainers(init)
+          .withContainers(containers)
+          .withVolumes(pipeVolume, configVolume, terminationVolume, tmpVolume)
+          .endSpec()
+          .build();
 
-    LOGGER.info("Creating pod {}...", pod.getMetadata().getName());
-    val start = System.currentTimeMillis();
+      LOGGER.info("Creating pod {}...", pod.getMetadata().getName());
+      val start = System.currentTimeMillis();
 
-    this.podDefinition = fabricClient.pods().inNamespace(namespace).createOrReplace(pod);
+      this.podDefinition = fabricClient.pods().inNamespace(namespace).createOrReplace(pod);
 
-    // We want to create a watch before the init container runs. Then we can guarantee
-    // that we're checking for updates across the full lifecycle of the main container.
-    // This is safe only because we are blocking the init pod until we copy files onto it.
-    // See the ExitCodeWatcher comments for more info.
-    exitCodeFuture = new CompletableFuture<>();
-    podInformer = fabricClient.pods()
-        .inNamespace(namespace)
-        .withName(pod.getMetadata().getName())
-        .inform();
-    podInformer.addEventHandler(new ExitCodeWatcher(
-        pod.getMetadata().getName(),
-        namespace,
-        exitCodeFuture::complete,
-        () -> {
-          LOGGER.info(prependPodInfo(
-              String.format(
-                  "Exit code watcher failed to retrieve the exit code. Defaulting to %s. This is expected if the job was cancelled.",
-                  KILLED_EXIT_CODE),
-              namespace,
-              podName));
+      // We want to create a watch before the init container runs. Then we can guarantee
+      // that we're checking for updates across the full lifecycle of the main container.
+      // This is safe only because we are blocking the init pod until we copy files onto it.
+      // See the ExitCodeWatcher comments for more info.
+      exitCodeFuture = new CompletableFuture<>();
+      podInformer = fabricClient.pods()
+          .inNamespace(namespace)
+          .withName(pod.getMetadata().getName())
+          .inform();
+      podInformer.addEventHandler(new ExitCodeWatcher(
+          pod.getMetadata().getName(),
+          namespace,
+          exitCodeFuture::complete,
+          () -> {
+            LOGGER.info(prependPodInfo(
+                String.format(
+                    "Exit code watcher failed to retrieve the exit code. Defaulting to %s. This is expected if the job was cancelled.",
+                    KILLED_EXIT_CODE),
+                namespace,
+                podName));
 
-          exitCodeFuture.complete(KILLED_EXIT_CODE);
-        }));
+            exitCodeFuture.complete(KILLED_EXIT_CODE);
+          }));
 
-    waitForInitPodToRun(fabricClient, podDefinition);
+      waitForInitPodToRun(fabricClient, podDefinition);
 
-    LOGGER.info("Copying files...");
-    copyFilesToKubeConfigVolume(fabricClient, podDefinition, files);
+      LOGGER.info("Copying files...");
+      copyFilesToKubeConfigVolume(fabricClient, podDefinition, files);
 
-    LOGGER.info("Waiting until pod is ready...");
-    // If a pod gets into a non-terminal error state it should be automatically killed by our
-    // heartbeating mechanism.
-    // This also handles the case where a very short pod already completes before this check completes
-    // the first time.
-    // This doesn't manage things like pods that are blocked from running for some cluster reason or if
-    // the init
-    // container got stuck somehow.
-    fabricClient.resource(podDefinition).waitUntilCondition(p -> {
-      final boolean isReady = Objects.nonNull(p) && Readiness.getInstance().isReady(p);
-      return isReady || KubePodResourceHelper.isTerminal(p);
-    }, 20, TimeUnit.MINUTES);
-    MetricClientFactory.getMetricClient().distribution(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS,
-        System.currentTimeMillis() - start);
+      LOGGER.info("Waiting until pod is ready...");
+      // If a pod gets into a non-terminal error state it should be automatically killed by our
+      // heartbeating mechanism.
+      // This also handles the case where a very short pod already completes before this check completes
+      // the first time.
+      // This doesn't manage things like pods that are blocked from running for some cluster reason or if
+      // the init
+      // container got stuck somehow.
+      fabricClient.resource(podDefinition).waitUntilCondition(p -> {
+        final boolean isReady = Objects.nonNull(p) && Readiness.getInstance().isReady(p);
+        return isReady || KubePodResourceHelper.isTerminal(p);
+      }, 20, TimeUnit.MINUTES);
+      MetricClientFactory.getMetricClient().distribution(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS,
+          System.currentTimeMillis() - start);
 
-    // allow writing stdin to pod
-    LOGGER.info("Reading pod IP...");
-    final var podIp = getPodIP(fabricClient, podName, namespace);
-    LOGGER.info("Pod IP: {}", podIp);
+      // allow writing stdin to pod
+      LOGGER.info("Reading pod IP...");
+      final var podIp = getPodIP(fabricClient, podName, namespace);
+      LOGGER.info("Pod IP: {}", podIp);
 
-    if (usesStdin) {
-      LOGGER.info("Creating stdin socket...");
-      final var socketToDestStdIo = new Socket(podIp, STDIN_REMOTE_PORT);
-      this.stdin = socketToDestStdIo.getOutputStream();
-    } else {
-      LOGGER.info("Using null stdin output stream...");
-      this.stdin = NullOutputStream.NULL_OUTPUT_STREAM;
+      if (usesStdin) {
+        LOGGER.info("Creating stdin socket...");
+        final var socketToDestStdIo = new Socket(podIp, STDIN_REMOTE_PORT);
+        this.stdin = socketToDestStdIo.getOutputStream();
+      } else {
+        LOGGER.info("Using null stdin output stream...");
+        this.stdin = NullOutputStream.NULL_OUTPUT_STREAM;
+      }
+    } catch (Exception e) {
+      // We need to make sure the ports are offered back
+      cleanup();
+      throw e; // Throw the exception again to inform the caller
     }
   }
 
@@ -686,6 +692,19 @@ public class KubePodProcess implements KubePod {
    */
   @Override
   public void destroy() {
+    cleanup();
+  }
+
+  /**
+   * cleanup destroys and returns any resources it has consumed this is a private method so that the
+   * constructor may call it.
+   */
+  private void cleanup() {
+    if (this.podDefinition == null) {
+      // no pod to destroy; just close resources
+      close();
+      return;
+    }
     final String podName = podDefinition.getMetadata().getName();
     final String podNamespace = podDefinition.getMetadata().getNamespace();
 
@@ -749,10 +768,18 @@ public class KubePodProcess implements KubePod {
       Exceptions.swallow(this.stderr::close);
     }
 
-    Exceptions.swallow(this.stdoutServerSocket::close);
-    Exceptions.swallow(this.stderrServerSocket::close);
-    Exceptions.swallow(this.podInformer::close);
-    Exceptions.swallow(this.executorService::shutdownNow);
+    if (this.stdoutServerSocket != null) {
+      Exceptions.swallow(this.stdoutServerSocket::close);
+    }
+    if (this.stderrServerSocket != null) {
+      Exceptions.swallow(this.stderrServerSocket::close);
+    }
+    if (this.podInformer != null) {
+      Exceptions.swallow(this.podInformer::close);
+    }
+    if (this.executorService != null) {
+      Exceptions.swallow(this.executorService::shutdownNow);
+    }
 
     KubePortManagerSingleton.getInstance().offer(stdoutLocalPort);
     KubePortManagerSingleton.getInstance().offer(stderrLocalPort);


### PR DESCRIPTION
…rces

If KubePodProcess fails to initialize its constructor the destroy() method is never called, so the ports remain claimed. this will eventually lead to port exhaustion.

This fix changes KubePodProcess constructor such that it catches any Exception during the initialization phase.
If it does detect an error, it will call cleanup() which offers the claimed ports back to the worker, and cleans up any other resources. Finally, it will re-throw the exception to inform the caller.

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.java`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [ ] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
