### PR TITLE
add JOB_KUBE_LABELS

### DIFF
--- a/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/sync/OrchestratorConstants.java
+++ b/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/sync/OrchestratorConstants.java
@@ -42,6 +42,7 @@ public class OrchestratorConstants {
           EnvConfigs.LOCAL_DOCKER_MOUNT,
           EnvConfigs.WORKSPACE_DOCKER_MOUNT,
           EnvConfigs.WORKSPACE_ROOT,
+          EnvConfigs.JOB_KUBE_LABELS,
           EnvConfigs.JOB_KUBE_NAMESPACE,
           EnvConfigs.JOB_MAIN_CONTAINER_CPU_REQUEST,
           EnvConfigs.JOB_MAIN_CONTAINER_CPU_LIMIT,

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/WorkerConfigs.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/WorkerConfigs.java
@@ -24,6 +24,7 @@ public class WorkerConfigs {
   private final Map<String, String> workerKubeNodeSelectors;
   private final Optional<Map<String, String>> workerIsolatedKubeNodeSelectors;
   private final Map<String, String> workerKubeAnnotations;
+  private final Map<String, String> workerKubeLabels;
   private final List<String> jobImagePullSecrets;
   private final String jobImagePullPolicy;
   private final String sidecarImagePullPolicy;
@@ -48,6 +49,7 @@ public class WorkerConfigs {
         configs.getJobKubeNodeSelectors(),
         configs.getUseCustomKubeNodeSelector() ? Optional.of(configs.getIsolatedJobKubeNodeSelectors()) : Optional.empty(),
         configs.getJobKubeAnnotations(),
+        configs.getJobKubeLabels(),
         configs.getJobKubeMainContainerImagePullSecrets(),
         configs.getJobKubeMainContainerImagePullPolicy(),
         configs.getJobKubeSidecarContainerImagePullPolicy(),
@@ -69,6 +71,10 @@ public class WorkerConfigs {
         ? configs.getSpecJobKubeAnnotations()
         : configs.getJobKubeAnnotations();
 
+    final Map<String, String> labels = configs.getSpecJobKubeLabels() != null
+        ? configs.getSpecJobKubeLabels()
+        : configs.getJobKubeLabels();
+
     return new WorkerConfigs(
         configs.getWorkerEnvironment(),
         new ResourceRequirements()
@@ -80,6 +86,7 @@ public class WorkerConfigs {
         nodeSelectors,
         configs.getUseCustomKubeNodeSelector() ? Optional.of(configs.getIsolatedJobKubeNodeSelectors()) : Optional.empty(),
         annotations,
+        labels,
         configs.getJobKubeMainContainerImagePullSecrets(),
         configs.getJobKubeMainContainerImagePullPolicy(),
         configs.getJobKubeSidecarContainerImagePullPolicy(),
@@ -101,6 +108,10 @@ public class WorkerConfigs {
         ? configs.getCheckJobKubeAnnotations()
         : configs.getJobKubeAnnotations();
 
+    final Map<String, String> labels = configs.getCheckJobKubeLabels() != null
+        ? configs.getCheckJobKubeLabels()
+        : configs.getJobKubeLabels();
+
     return new WorkerConfigs(
         configs.getWorkerEnvironment(),
         new ResourceRequirements()
@@ -112,6 +123,7 @@ public class WorkerConfigs {
         nodeSelectors,
         configs.getUseCustomKubeNodeSelector() ? Optional.of(configs.getIsolatedJobKubeNodeSelectors()) : Optional.empty(),
         annotations,
+        labels,
         configs.getJobKubeMainContainerImagePullSecrets(),
         configs.getJobKubeMainContainerImagePullPolicy(),
         configs.getJobKubeSidecarContainerImagePullPolicy(),
@@ -133,6 +145,10 @@ public class WorkerConfigs {
         ? configs.getDiscoverJobKubeAnnotations()
         : configs.getJobKubeAnnotations();
 
+    final Map<String, String> labels = configs.getDiscoverJobKubeLabels() != null
+        ? configs.getDiscoverJobKubeLabels()
+        : configs.getJobKubeLabels();
+
     return new WorkerConfigs(
         configs.getWorkerEnvironment(),
         new ResourceRequirements()
@@ -144,6 +160,7 @@ public class WorkerConfigs {
         nodeSelectors,
         configs.getUseCustomKubeNodeSelector() ? Optional.of(configs.getIsolatedJobKubeNodeSelectors()) : Optional.empty(),
         annotations,
+        labels,
         configs.getJobKubeMainContainerImagePullSecrets(),
         configs.getJobKubeMainContainerImagePullPolicy(),
         configs.getJobKubeSidecarContainerImagePullPolicy(),
@@ -171,6 +188,7 @@ public class WorkerConfigs {
         configs.getJobKubeNodeSelectors(),
         configs.getUseCustomKubeNodeSelector() ? Optional.of(configs.getIsolatedJobKubeNodeSelectors()) : Optional.empty(),
         configs.getJobKubeAnnotations(),
+        configs.getJobKubeLabels(),
         configs.getJobKubeMainContainerImagePullSecrets(),
         configs.getJobKubeMainContainerImagePullPolicy(),
         configs.getJobKubeSidecarContainerImagePullPolicy(),
@@ -202,6 +220,9 @@ public class WorkerConfigs {
 
   public Map<String, String> getWorkerKubeAnnotations() {
     return workerKubeAnnotations;
+  }
+  public Map<String, String> getWorkerKubeLabels() {
+    return workerKubeLabels;
   }
 
   public List<String> getJobImagePullSecrets() {

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/config/KubeResourceConfig.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/config/KubeResourceConfig.java
@@ -17,6 +17,7 @@ final class KubeResourceConfig {
 
   private final String name;
   private String annotations;
+  private String labels;
   private String nodeSelectors;
   private String cpuLimit;
   private String cpuRequest;
@@ -33,6 +34,10 @@ final class KubeResourceConfig {
 
   public String getAnnotations() {
     return annotations;
+  }
+
+  public String getLabels() {
+    return labels;
   }
 
   public String getNodeSelectors() {
@@ -57,6 +62,10 @@ final class KubeResourceConfig {
 
   public void setAnnotations(String annotations) {
     this.annotations = annotations;
+  }
+
+  public void setLabels(String labels) {
+    this.labels = labels;
   }
 
   public void setNodeSelectors(String nodeSelectors) {

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/config/WorkerConfigsProvider.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/config/WorkerConfigsProvider.java
@@ -118,6 +118,7 @@ public class WorkerConfigsProvider {
         splitKVPairsFromEnvString(kubeResourceConfig.getNodeSelectors()),
         workerConfigsDefaults.useCustomNodeSelector() ? Optional.of(isolatedNodeSelectors) : Optional.empty(),
         splitKVPairsFromEnvString(kubeResourceConfig.getAnnotations()),
+        splitKVPairsFromEnvString(kubeResourceConfig.getLabels()),
         workerConfigsDefaults.mainContainerImagePullSecret(),
         workerConfigsDefaults.mainContainerImagePullPolicy(),
         workerConfigsDefaults.sidecarContainerImagePullPolicy(),

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/sync/LauncherWorker.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/sync/LauncherWorker.java
@@ -36,6 +36,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.temporal.activity.ActivityExecutionContext;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,7 +151,8 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
         final var allLabels = KubeProcessFactory.getLabels(
             jobRunConfig.getJobId(),
             Math.toIntExact(jobRunConfig.getAttemptId()),
-            generateMetadataLabels());
+            generateMetadataLabels(),
+            Collections.emptyMap());
 
         final var podNameAndJobPrefix = podNamePrefix + "-job-" + jobRunConfig.getJobId() + "-attempt-";
         final var podName = podNameAndJobPrefix + jobRunConfig.getAttemptId();

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -476,6 +476,27 @@ public interface Configs {
   Map<String, String> getDiscoverJobKubeAnnotations();
 
   /**
+   * Define one or more Job pod labels. Each kv-pair is separated by a `,`. Used for the sync job
+   * and as fallback in case job specific (spec, check, discover) annotations are not defined.
+   */
+  Map<String, String> getJobKubeLabels();
+
+  /**
+   * Define labels for Spec job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Map<String, String> getSpecJobKubeLabels();
+
+  /**
+   * Define labels for Check job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Map<String, String> getCheckJobKubeLabels();
+
+  /**
+   * Define labels for Discover job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Map<String, String> getDiscoverJobKubeLabels();
+
+  /**
    * Define the Job pod connector image pull policy.
    */
   String getJobKubeMainContainerImagePullPolicy();

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -78,6 +78,7 @@ public class EnvConfigs implements Configs {
   public static final String JOB_ISOLATED_KUBE_NODE_SELECTORS = "JOB_ISOLATED_KUBE_NODE_SELECTORS";
   public static final String USE_CUSTOM_NODE_SELECTOR = "USE_CUSTOM_NODE_SELECTOR";
   public static final String JOB_KUBE_ANNOTATIONS = "JOB_KUBE_ANNOTATIONS";
+  public static final String JOB_KUBE_LABELS = "JOB_KUBE_LABELS";
   private static final String DEFAULT_SIDECAR_MEMORY_REQUEST = "25Mi";
   private static final String SIDECAR_MEMORY_REQUEST = "SIDECAR_MEMORY_REQUEST";
   private static final String DEFAULT_SIDECAR_KUBE_MEMORY_LIMIT = "50Mi";
@@ -181,6 +182,9 @@ public class EnvConfigs implements Configs {
   public static final String SPEC_JOB_KUBE_ANNOTATIONS = "SPEC_JOB_KUBE_ANNOTATIONS";
   public static final String CHECK_JOB_KUBE_ANNOTATIONS = "CHECK_JOB_KUBE_ANNOTATIONS";
   public static final String DISCOVER_JOB_KUBE_ANNOTATIONS = "DISCOVER_JOB_KUBE_ANNOTATIONS";
+  public static final String SPEC_JOB_KUBE_LABELS = "SPEC_JOB_KUBE_LABELS";
+  public static final String DISCOVER_JOB_KUBE_LABELS = "DISCOVER_JOB_KUBE_LABELS";
+  public static final String CHECK_JOB_KUBE_LABELS = "CHECK_JOB_KUBE_LABELS";
 
   private static final String REPLICATION_ORCHESTRATOR_CPU_REQUEST = "REPLICATION_ORCHESTRATOR_CPU_REQUEST";
   private static final String REPLICATION_ORCHESTRATOR_CPU_LIMIT = "REPLICATION_ORCHESTRATOR_CPU_LIMIT";
@@ -735,6 +739,51 @@ public class EnvConfigs implements Configs {
   @Override
   public Map<String, String> getDiscoverJobKubeAnnotations() {
     return splitKVPairsFromEnvString(getEnvOrDefault(DISCOVER_JOB_KUBE_ANNOTATIONS, ""));
+  }
+
+  /**
+   * Returns a map of labels from its own environment variable. The value of the env is a string
+   * that represents one or more labels. Each kv-pair is separated by a `,`
+   * <p>
+   * For example:- The following represents two labels
+   * <p>
+   * airbyte=worker,type=preemptive
+   *
+   * @return map containing kv pairs of labels, or `null` if none present.
+   */
+  @Override
+  public Map<String, String> getJobKubeLabels() {
+    return splitKVPairsFromEnvString(getEnvOrDefault(JOB_KUBE_LABELS, ""));
+  }
+
+  /**
+   * Returns a map of labels for Spec job pods specifically.
+   *
+   * @return map containing kv pairs of labels, or `null` if none present.
+   */
+  @Override
+  public Map<String, String> getSpecJobKubeLabels() {
+    return splitKVPairsFromEnvString(getEnvOrDefault(SPEC_JOB_KUBE_LABELS, ""));
+  }
+
+  /**
+   * Returns a map of labels for Check job pods specifically.
+   *
+   * @return map containing kv pairs of labels, or `null` if none present.
+   */
+  @Override
+  public Map<String, String> getCheckJobKubeLabels() {
+    return splitKVPairsFromEnvString(getEnvOrDefault(CHECK_JOB_KUBE_LABELS, ""));
+  }
+
+  /**
+   * Returns a map of labels for Discover job pods specifically.
+   *
+   * @return map containing kv pairs of labels, or `null` if none present.
+   */
+  @Override
+  public Map<String, String> getDiscoverJobKubeLabels() {
+    return splitKVPairsFromEnvString(getEnvOrDefault(DISCOVER_JOB_KUBE_LABELS, ""));
   }
 
   /**

--- a/airbyte-workers/src/main/resources/application.yml
+++ b/airbyte-workers/src/main/resources/application.yml
@@ -112,6 +112,7 @@ airbyte:
     kube-job-configs:
       default:
         annotations: ${JOB_KUBE_ANNOTATIONS:}
+        labels: ${JOB_KUBE_LABELS:}
         node-selectors: ${JOB_KUBE_NODE_SELECTORS:}
         cpu-limit: ${JOB_MAIN_CONTAINER_CPU_LIMIT:}
         cpu-request: ${JOB_MAIN_CONTAINER_CPU_REQUEST:}
@@ -119,6 +120,7 @@ airbyte:
         memory-request: ${JOB_MAIN_CONTAINER_MEMORY_REQUEST:}
       check:
         annotations: ${CHECK_JOB_KUBE_ANNOTATIONS:}
+        labels: ${CHECK_JOB_KUBE_LABELS:}
         node-selectors: ${CHECK_JOB_KUBE_NODE_SELECTORS:}
         cpu-limit: ${CHECK_JOB_MAIN_CONTAINER_CPU_LIMIT:}
         cpu-request: ${CHECK_JOB_MAIN_CONTAINER_CPU_REQUEST:}
@@ -126,6 +128,7 @@ airbyte:
         memory-request: ${CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST:}
       discover:
         annotations: ${DISCOVER_JOB_KUBE_ANNOTATIONS:}
+        labels: ${DISCOVER_JOB_KUBE_LABELS:}
         node-selectors: ${DISCOVER_JOB_KUBE_NODE_SELECTORS:}
       normalization:
         cpu-limit: ${NORMALIZATION_JOB_MAIN_CONTAINER_CPU_LIMIT:}
@@ -134,6 +137,7 @@ airbyte:
         memory-request: ${NORMALIZATION_JOB_MAIN_CONTAINER_MEMORY_REQUEST:}
       replication:
         annotations: ${JOB_KUBE_ANNOTATIONS:}
+        labels: ${JOB_KUBE_LABELS:}
         node-selectors: ${JOB_KUBE_NODE_SELECTORS:}
         cpu-limit: ${REPLICATION_ORCHESTRATOR_CPU_LIMIT:}
         cpu-request: ${REPLICATION_ORCHESTRATOR_CPU_REQUEST:}
@@ -141,6 +145,7 @@ airbyte:
         memory-request: ${REPLICATION_ORCHESTRATOR_MEMORY_REQUEST:}
       spec:
         annotations: ${SPEC_JOB_KUBE_ANNOTATIONS:}
+        labels: ${SPEC_JOB_KUBE_LABELS:}
         node-selectors: ${SPEC_JOB_KUBE_NODE_SELECTORS:}
     check:
       enabled: ${SHOULD_RUN_CHECK_CONNECTION_WORKFLOWS:true}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/config/WorkerConfigProviderMicronautTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/config/WorkerConfigProviderMicronautTest.java
@@ -45,6 +45,7 @@ class WorkerConfigProviderMicronautTest {
   void testKubeConfigIsReadingAllTheFields() {
     assertEquals("check", checkKubeResourceConfig.getName());
     assertEquals("check annotations", checkKubeResourceConfig.getAnnotations());
+    assertEquals("check labels", checkKubeResourceConfig.getLabels());
     assertEquals("check node-selectors", checkKubeResourceConfig.getNodeSelectors());
     assertEquals("check cpu limit", checkKubeResourceConfig.getCpuLimit());
     assertEquals("check cpu request", checkKubeResourceConfig.getCpuRequest());
@@ -56,6 +57,7 @@ class WorkerConfigProviderMicronautTest {
   void testDefaultFieldBehavior() {
     assertEquals("spec", specKubeResourceConfig.getName());
     assertEquals("spec annotations", specKubeResourceConfig.getAnnotations());
+    assertEquals("spec labels", specKubeResourceConfig.getLabels());
     assertEquals("spec node selectors", specKubeResourceConfig.getNodeSelectors());
     assertNull(specKubeResourceConfig.getCpuLimit());
     assertNull(specKubeResourceConfig.getCpuRequest());

--- a/airbyte-workers/src/test/resources/application-config-test.yaml
+++ b/airbyte-workers/src/test/resources/application-config-test.yaml
@@ -8,6 +8,7 @@ airbyte:
         cpu-limit: default cpu limit
       check:
         annotations: ${CHECK_JOB_KUBE_ANNOTATIONS:check annotations}
+        labels: ${CHECK_JOB_KUBE_LABELS:check labels}
         node-selectors: ${CHECK_JOB_KUBE_NODE_SELECTORS:check node-selectors}
         cpu-limit: ${CHECK_JOB_MAIN_CONTAINER_CPU_LIMIT:check cpu limit}
         cpu-request: ${CHECK_JOB_MAIN_CONTAINER_CPU_REQUEST:check cpu request}
@@ -15,6 +16,7 @@ airbyte:
         memory-request: ${CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST:check mem request}
       spec:
         annotations: ${SPEC_JOB_KUBE_ANNOTATIONS:spec annotations}
+        labels: ${SPEC_JOB_KUBE_LABELS:spec labels}
         node-selectors: ${SPEC_JOB_KUBE_NODE_SELECTORS:spec node selectors}
         memory-limit: spec memory limit
         memory-request: ${SOMETHING_NOT_THERE:}

--- a/charts/airbyte-worker/README.md
+++ b/charts/airbyte-worker/README.md
@@ -34,6 +34,7 @@ Helm chart to deploy airbyte-worker
 | global.extraLabels | object | `{}` |  |
 | global.extraSelectorLabels | object | `{}` |  |
 | global.jobs.kube.annotations | object | `{}` |  |
+| global.jobs.kube.labels | object | `{}` |  |
 | global.jobs.kube.images.busybox | string | `""` |  |
 | global.jobs.kube.images.curl | string | `""` |  |
 | global.jobs.kube.images.socat | string | `""` |  |

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -138,6 +138,13 @@ spec:
               name: {{ .Release.Name }}-airbyte-env
               key: JOB_KUBE_ANNOTATIONS
         {{- end }}
+        {{- if .Values.global.jobs.kube.labels }}
+        - name: JOB_KUBE_LABELS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: JOB_KUBE_LABELS
+        {{- end }}
         {{- if $.Values.global.jobs.kube.nodeSelector }}
         - name: JOB_KUBE_NODE_SELECTORS
           valueFrom:

--- a/charts/airbyte-worker/values.yaml
+++ b/charts/airbyte-worker/values.yaml
@@ -87,6 +87,11 @@ global:
       ##  jobs.kube.annotations [object] key/value annotations applied to kube jobs
       annotations: {}
 
+      ## JOB_KUBE_LABELS
+      ## pod labels of the sync job and the default pod labels fallback for others jobs
+      ##  jobs.kube.labels [object] key/value labels applied to kube jobs
+      labels: {}
+
       ## JOB_KUBE_NODE_SELECTORS
       ## pod node selector of the sync job and the default pod node selector fallback for others jobs
       ##  jobs.kube.nodeSelector [object] key/value node selector applied to kube jobs
@@ -359,9 +364,10 @@ secrets: {}
 #   NORMALIZATION_JOB_MAIN_CONTAINER_CPU_LIMIT:
 #   NORMALIZATION_JOB_MAIN_CONTAINER_CPU_REQUEST:
 
-#   # Worker pod tolerations, annotations and node selectors
+#   # Job pod tolerations, annotations, labels and node selectors
 #   JOB_KUBE_TOLERATIONS:
 #   JOB_KUBE_ANNOTATIONS:
+#   JOB_KUBE_LABELS:
 #   JOB_KUBE_NODE_SELECTORS:
 
 #   # Job image pull policy

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -96,6 +96,7 @@ Helm chart to deploy airbyte
 | global.database.secretValue | string | `""` |  |
 | global.deploymentMode | string | `"oss"` |  |
 | global.jobs.kube.annotations | object | `{}` |  |
+| global.jobs.kube.labels | object | `{}` |  |
 | global.jobs.kube.images.busybox | string | `""` |  |
 | global.jobs.kube.images.curl | string | `""` |  |
 | global.jobs.kube.images.socat | string | `""` |  |

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -27,6 +27,9 @@ data:
 {{- if $.Values.global.jobs.kube.annotations }}
   JOB_KUBE_ANNOTATIONS: {{ $.Values.global.jobs.kube.annotations | include "airbyte.flattenMap" | quote }}
 {{- end }}
+{{- if $.Values.global.jobs.kube.labels }}
+  JOB_KUBE_LABELS: {{ $.Values.global.jobs.kube.labels | include "airbyte.flattenMap" | quote }}
+{{- end }}
 {{- if $.Values.global.jobs.kube.nodeSelector }}
   JOB_KUBE_NODE_SELECTORS: {{ $.Values.global.jobs.kube.nodeSelector | include "airbyte.flattenMap" | quote }}
 {{- end }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -110,6 +110,11 @@ global:
       ##  jobs.kube.annotations [object] key/value annotations applied to kube jobs
       annotations: {}
 
+      ## JOB_KUBE_LABELS
+      ## pod labels of the sync job and the default pod labels fallback for others jobs
+      ##  jobs.kube.labels [object] key/value labels applied to kube jobs
+      labels: {}
+
       ## JOB_KUBE_NODE_SELECTORS
       ## pod node selector of the sync job and the default pod node selector fallback for others jobs
       ##  jobs.kube.nodeSelector [object] key/value node selector applied to kube jobs

--- a/charts/airbyte/values.yaml.test
+++ b/charts/airbyte/values.yaml.test
@@ -112,6 +112,11 @@ global:
       ##  jobs.kube.annotations [object] key/value annotations applied to kube jobs
       annotations: {}
 
+      ## JOB_KUBE_LABELS
+      ## pod labels of the sync job and the default pod labels fallback for others jobs
+      ##  jobs.kube.labels [object] key/value labels applied to kube jobs
+      labels: {}
+
       ## JOB_KUBE_NODE_SELECTORS
       ## pod node selector of the sync job and the default pod node selector fallback for others jobs
       ##  jobs.kube.nodeSelector [object] key/value node selector applied to kube jobs


### PR DESCRIPTION
## What
Resolves: https://github.com/airbytehq/airbyte/issues/7790

## How
Add `JOB_KUBE_LABELS` env variable in a similar to `JOB_KUBE_ANNOTATIONS` way.

The differences are:
- update `ENV_VARS_TO_TRANSFER` to pass the labels variable to an orchestrator pod
- change `KubeProcessFactory.getLabels` to accept labels from `JOB_KUBE_LABELS` (with the lowerst priority if the keys are 

There are **some limitations** in the way how config works with Micronaut as of now. It requires `CHECK`, `DISCOVER`, `SPEC` prefixed variables to run specific jobs and do not fallback to default. This problem exists for other `JOB_KUBE_*` variables and it seems like some refactoring is ongoing, so I left it out.

I also left out `JOB_KUBE_LABELS` for normalization jobs. I did it because other `JOB_KUBE_*` variables behave in the same way and I have no easy way to test this feature.

## Recommended reading order
Configs
1. `airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java`
2. `airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java`
3. `airbyte-commons-worker/src/main/java/io/airbyte/workers/WorkerConfigs.java`
4. `airbyte-workers/src/main/resources/application.yml`
5. `airbyte-commons-worker/src/main/java/io/airbyte/workers/config/KubeResourceConfig.java`
6. `airbyte-commons-worker/src/main/java/io/airbyte/workers/config/WorkerConfigsProvider.java`
7. `airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/sync/OrchestratorConstants.java`

Tests
1. `airbyte-workers/src/test/java/io/airbyte/workers/config/WorkerConfigProviderMicronautTest.java`
2. `airbyte-workers/src/test/resources/application-config-test.yaml`

Process Creation
1. `airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java`
2. `airbyte-commons-worker/src/main/java/io/airbyte/workers/sync/LauncherWorker.java`

Helm
1. `charts/airbyte-worker/values.yaml`
2. `charts/airbyte-worker/templates/deployment.yaml`
3. `charts/airbyte/values.yaml.test`
4. `charts/airbyte/values.yaml`
5. `charts/airbyte/templates/env-configmap.yaml`


## Can this PR be safely reverted / rolled back?
*If unsure, leave it blank.*
- [ ] YES 💚
- [ ] NO ❌
