### PR TITLE
support existing secrets for aws creds

### DIFF
--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -23,3 +23,4 @@ stringData:
   STATE_STORAGE_MINIO_ACCESS_KEY: {{ .Values.minio.auth.rootUser | quote }}
   STATE_STORAGE_MINIO_SECRET_ACCESS_KEY: {{ .Values.minio.auth.rootPassword | quote }}
 {{- end }}
+

--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -10,8 +10,12 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{ if eq .Values.global.logs.accessKey.existingSecret "" -}}
   AWS_ACCESS_KEY_ID: {{ .Values.global.logs.accessKey.password | quote }}
+  {{- end }}
+  {{ if eq .Values.global.logs.secretKey.existingSecret "" -}}
   AWS_SECRET_ACCESS_KEY: {{ .Values.global.logs.secretKey.password | quote }}
+  {{- end }}
   {{ if eq .Values.externalDatabase.existingSecret "" -}}
   DATABASE_PASSWORD: {{ .Values.externalDatabase.password | default .Values.postgresql.postgresqlPassword | quote }}
   {{ end -}}


### PR DESCRIPTION
## What
Partially addresses https://github.com/airbytehq/airbyte/issues/22529
There are helm values to override `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` with existing secrets, but at the moment they don't seem to work. I added some logic to support these values.

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌