### PR TITLE
Enable CustomDbtNormalization on k8s

### DIFF
--- a/airbyte-commons-worker/src/main/resources/dbt_transformation_entrypoint.sh
+++ b/airbyte-commons-worker/src/main/resources/dbt_transformation_entrypoint.sh
@@ -2,6 +2,18 @@
 set -e
 
 CWD=$(pwd)
+if [[ ! -d git_repo ]]
+then
+  echo "Preparing environment to build dbt profile...\n"
+  echo "Instaling jq lib..."
+  apt update && apt install jq tree -y
+  echo "Cloning data in pod..."
+  cat dbt_config.json | jq '"git clone --depth 5 -b " + (.gitRepoBranch) + " --single-branch " + (.gitRepoUrl) + " git_repo"' | xargs /bin/bash -c
+  echo "Generating profiles.yaml ..."
+  python generate_profile.py
+  echo "Listing folders ... tree -L 2"
+  tree -L 2
+fi
 # change directory to be inside git_repo that was just cloned
 cd git_repo
 echo "Running from $(pwd)"

--- a/airbyte-commons-worker/src/main/resources/generate_profile.py
+++ b/airbyte-commons-worker/src/main/resources/generate_profile.py
@@ -1,0 +1,64 @@
+import yaml
+import json
+import re
+
+default_bq_profile = {
+    "config": {
+        "partial_parse": True,
+        "printer_width": 120,
+        "send_anonymous_usage_stats": False,
+        "use_colors": True
+    },
+    "normalize": {
+        "outputs": {
+            "prod": {
+                "dataset": "",
+                "keyfile_json": {},
+                "location": "",
+                "method": "service-account-json",
+                "priority": "interactive",
+                "project": "",
+                "retries": 3,
+                "threads": 8,
+                "type": "bigquery"
+            }
+        },
+        "target": "prod"
+    }
+}
+
+if __name__ == "__main__":
+    print("Reading destination config data and parsing...")
+    with open("destination_config.json") as f:
+        dest_conf = json.loads(f.read())
+    
+    profile_vars = {
+        "dataset": dest_conf["dataset_id"],
+        "location": dest_conf["dataset_location"],
+        "project": dest_conf["project_id"],
+        "keyfile_json": json.loads(dest_conf['credentials_json'])
+    }
+    default_bq_profile["normalize"]["outputs"]["prod"].update(profile_vars)
+    
+    print("Writing dbt profile to execute...")
+    with open("profiles.yml", "w") as f:
+        f.write(yaml.dump(default_bq_profile))
+
+    print("Checking if need to fix --project-dir if not pointing to /config/git_repo...")
+    with open("dbt_config.json") as f:
+        dbt_config = json.loads(f.read())
+
+    if "--project-dir" in dbt_config["dbtArguments"]:
+        print("Project dir setted in arguments... checking correct path...")
+        dbt_args = dbt_config["dbtArguments"]
+        pattern = r"(?<=--project-dir )(.*?)(?=[\b|\s]|$)"
+        found = re.findall(pattern, dbt_args)[0]
+        if "/config/git_repo" not in found:
+            dbt_config['dbtArguments'] = re.sub(pattern, r"/config/git_repo/{}".format(found), dbt_args)
+        
+        with open("dbt_config.json", "w") as f:
+            f.write(json.dumps(dbt_config))
+
+    else:
+        print("Nothing to fix...")
+    


### PR DESCRIPTION
Solves the issue [5091](https://github.com/airbytehq/airbyte/issues/5091) - now, only for bigquery destination.

The purpose of this modifications is to "re-clone" the repo inside the pod if the folder doesn't exists. It reuses the structure of the NormalizationRunner.

At this points it uses a custom script to create the profile of bigquery destination. The better form is to reuse the transform-config script to create the dbt profile (pls someone should help me on that).

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*
Enable CustomDbtNormalization on k8s

## How
*Describe the solution*
Added the NormalizationRunner steps to DbtNormalizationRunner and enforced the creation of git_repo inside the normalization pod.

## Recommended reading order
1. `x.java`
2. `y.java`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
