### PR TITLE
Use AWS credentials from secret

### DIFF
--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -167,6 +167,20 @@ spec:
               name: {{ .Values.global.logs.secretKey.existingSecret }}
               key: {{ .Values.global.logs.secretKey.existingSecretKey }}
         {{- end }}
+        {{- if and .Values.global.logs.s3.enabled .Values.global.logs.accessKey.password }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_ACCESS_KEY_ID
+        {{- end }}
+        {{- if and .Values.global.logs.s3.enabled .Values.global.logs.secretKey.password }}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_SECRET_ACCESS_KEY
+        {{- end }}
         {{- if or .Values.global.logs.minio.enabled .Values.global.logs.externalMinio.enabled }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -229,6 +229,20 @@ spec:
               name: {{ .Values.global.logs.secretKey.existingSecret }}
               key: {{ .Values.global.logs.secretKey.existingSecretKey }}
         {{- end }}
+        {{- if and .Values.global.logs.s3.enabled .Values.global.logs.accessKey.password }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_ACCESS_KEY_ID
+        {{- end }}
+        {{- if and .Values.global.logs.s3.enabled .Values.global.logs.secretKey.password }}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_SECRET_ACCESS_KEY
+        {{- end }}
         {{- if or .Values.global.logs.minio.enabled .Values.global.logs.externalMinio.enabled }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:


### PR DESCRIPTION
## What
*Describe what the change is solving It helps to add screenshots if it affects the frontend.*

Changes in Helm charts use AWS credentials from secret.
Secret is created with different template
https://github.com/airbytehq/airbyte-platform/blob/e7dbb2c61914a575dbc8aafadbd89644bd27fb48/charts/airbyte/templates/secret.yaml#L13-L14

## How
*Describe the solution*

I extended existing template to use AWS credentials if s3 is enabled and corresponding values in `password` exist.

## Recommended reading order
1. `charts/airbyte-server/templates/deployment.yaml`
2. `charts/airbyte-worker/templates/deployment.yaml`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [ ] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Extra details

I run `helm upgrade airbyte airbyte/airbyte --install -f values.yaml` with `values.yaml` like below:

```
global:
  state:
    storage:
      type: "S3"
  logs:
    accessKey:
      password: "XXXXXXXXXXXXXXXXXXXX"
    secretKey:
      password: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
    storage:
      type: "S3"
    minio:
      enabled: false

postgresql:
  enabled: false

minio:
  enabled: false

externalDatabase:
  host: airbyte.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  user: root
  password: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  database: airbyte
  port: 5432
  jdbcUrl: "jdbc:postgresql://airbyte.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:5432/airbyte"
# ... and many other fields hidden for readability
```

In airbyte-server logs I got

```
2023-05-22 08:31:05 ERROR i.m.r.Micronaut(handleStartupException):338 - Error starting Micronaut server: null
java.lang.IllegalArgumentException: null
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:131) ~[guava-31.1-jre.jar:?]
	at io.airbyte.config.storage.DefaultS3ClientFactory.validateBase(DefaultS3ClientFactory.java:36) ~[io.airbyte.airbyte-config-config-models-0.44.4.jar:?]
	at io.airbyte.config.storage.DefaultS3ClientFactory.validate(DefaultS3ClientFactory.java:31) ~[io.airbyte.airbyte-config-config-models-0.44.4.jar:?]
	at io.airbyte.config.storage.DefaultS3ClientFactory.<init>(DefaultS3ClientFactory.java:24) ~[io.airbyte.airbyte-config-config-models-0.44.4.jar:?]
	at io.airbyte.config.helpers.CloudLogs.createCloudLogClient(CloudLogs.java:51) ~[io.airbyte.airbyte-config-config-models-0.44.4.jar:?]
	at io.airbyte.config.helpers.LogClientSingleton.createCloudClientIfNull(LogClientSingleton.java:226) ~[io.airbyte.airbyte-config-config-models-0.44.4.jar:?]
	at io.airbyte.config.helpers.LogClientSingleton.setWorkspaceMdc(LogClientSingleton.java:213) ~[io.airbyte.airbyte-config-config-models-0.44.4.jar:?]
	at io.airbyte.server.LoggingEventListener.onApplicationEvent(LoggingEventListener.java:34) ~[io.airbyte-airbyte-server-0.44.4.jar:?]
	at io.airbyte.server.LoggingEventListener.onApplicationEvent(LoggingEventListener.java:21) ~[io.airbyte-airbyte-server-0.44.4.jar:?]
	at io.micronaut.context.event.ApplicationEventPublisherFactory.notifyEventListeners(ApplicationEventPublisherFactory.java:262) ~[micronaut-inject-3.9.0.jar:3.9.0]
	at io.micronaut.context.event.ApplicationEventPublisherFactory.access$200(ApplicationEventPublisherFactory.java:60) ~[micronaut-inject-3.9.0.jar:3.9.0]
	at io.micronaut.context.event.ApplicationEventPublisherFactory$2.publishEvent(ApplicationEventPublisherFactory.java:229) ~[micronaut-inject-3.9.0.jar:3.9.0]
	at io.micronaut.http.server.netty.NettyHttpServer.lambda$fireStartupEvents$15(NettyHttpServer.java:587) ~[micronaut-http-server-netty-3.9.0.jar:3.9.0]
	at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at io.micronaut.http.server.netty.NettyHttpServer.fireStartupEvents(NettyHttpServer.java:581) ~[micronaut-http-server-netty-3.9.0.jar:3.9.0]
	at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:298) ~[micronaut-http-server-netty-3.9.0.jar:3.9.0]
	at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:104) ~[micronaut-http-server-netty-3.9.0.jar:3.9.0]
	at io.micronaut.runtime.Micronaut.lambda$start$2(Micronaut.java:81) ~[micronaut-context-3.9.0.jar:3.9.0]
	at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at io.micronaut.runtime.Micronaut.start(Micronaut.java:79) ~[micronaut-context-3.9.0.jar:3.9.0]
	at io.micronaut.runtime.Micronaut.run(Micronaut.java:323) ~[micronaut-context-3.9.0.jar:3.9.0]
	at io.micronaut.runtime.Micronaut.run(Micronaut.java:309) ~[micronaut-context-3.9.0.jar:3.9.0]
	at io.airbyte.server.Application.main(Application.java:15) ~[io.airbyte-airbyte-server-0.44.4.jar:?]
```