### PR TITLE
Fix for 100% IPv6 network/kube clusters.

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -45,12 +45,15 @@ public class KubeProcessFactory implements ProcessFactory {
                             final String namespace,
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl) {
+    // Need to process the IP Address before passing it down IPv6 needs brackets.
+    final String runnerHostIP = InetAddress.getLocalHost().getHostAddress()));
+    final String processRunnerHost = runnerHostIP.contains(":") ? "[" + localIp + "]:" + serverPort : runnerHostIP + ":" + serverPort; 
     this(
         workerConfigsProvider,
         namespace,
         fabricClient,
         kubeHeartbeatUrl,
-        Exceptions.toRuntime(() -> InetAddress.getLocalHost().getHostAddress()));
+        Exceptions.toRuntime(() -> processRunnerHost;
   }
 
   /**

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -37,7 +37,7 @@ public class KubeProcessFactory implements ProcessFactory {
   private final KubernetesClient fabricClient;
   private final String kubeHeartbeatUrl;
   private final String processRunnerHost;
-
+  
   /**
    * Sets up a process factory with the default processRunnerHost.
    */
@@ -46,14 +46,12 @@ public class KubeProcessFactory implements ProcessFactory {
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl) {
     // Need to process the IP Address before passing it down IPv6 needs brackets.
-    final String runnerHostIP = InetAddress.getLocalHost().getHostAddress();
-    final String processRunnerHost = runnerHostIP.contains(":") ? "[" + localIp + "]:" + serverPort : runnerHostIP + ":" + serverPort; 
     this(
         workerConfigsProvider,
         namespace,
         fabricClient,
         kubeHeartbeatUrl,
-        Exceptions.toRuntime(() -> processRunnerHost);
+        Exceptions.toRuntime(() -> InetAddress.getLocalHost().getHostAddress()));
   }
 
   /**
@@ -76,7 +74,8 @@ public class KubeProcessFactory implements ProcessFactory {
     this.namespace = namespace;
     this.fabricClient = fabricClient;
     this.kubeHeartbeatUrl = kubeHeartbeatUrl;
-    this.processRunnerHost = processRunnerHost;
+    this.processRunnerHost = processRunnerHost.contains(":") ? "[" + processRunnerHost + "]" : processRunnerHost; 
+    ;
   }
 
   @Override

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -74,8 +74,7 @@ public class KubeProcessFactory implements ProcessFactory {
     this.namespace = namespace;
     this.fabricClient = fabricClient;
     this.kubeHeartbeatUrl = kubeHeartbeatUrl;
-    this.processRunnerHost = processRunnerHost.contains(":") ? "[" + processRunnerHost + "]" : processRunnerHost; 
-    ;
+    this.processRunnerHost = processRunnerHost.contains(":") ? "[" + processRunnerHost + "]" : processRunnerHost; // IPv6 needs brackets.
   }
 
   @Override

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -46,14 +46,14 @@ public class KubeProcessFactory implements ProcessFactory {
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl) {
     // Need to process the IP Address before passing it down IPv6 needs brackets.
-    final String runnerHostIP = InetAddress.getLocalHost().getHostAddress()));
+    final String runnerHostIP = InetAddress.getLocalHost().getHostAddress();
     final String processRunnerHost = runnerHostIP.contains(":") ? "[" + localIp + "]:" + serverPort : runnerHostIP + ":" + serverPort; 
     this(
         workerConfigsProvider,
         namespace,
         fabricClient,
         kubeHeartbeatUrl,
-        Exceptions.toRuntime(() -> processRunnerHost;
+        Exceptions.toRuntime(() -> processRunnerHost);
   }
 
   /**

--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/config/ContainerOrchestratorFactory.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/config/ContainerOrchestratorFactory.java
@@ -76,7 +76,7 @@ class ContainerOrchestratorFactory {
                                     @Value("${micronaut.server.port}") final int serverPort)
       throws UnknownHostException {
     final var localIp = InetAddress.getLocalHost().getHostAddress();
-    final var kubeHeartbeatUrl = localIp + ":" + serverPort;
+    final String kubeHeartbeatUrl = localIp.contains(":") ? "[" + localIp + "]:" + serverPort : localIp + ":" + serverPort;
 
     // this needs to have two ports for the source and two ports for the destination (all four must be
     // exposed)

--- a/airbyte-temporal/Dockerfile
+++ b/airbyte-temporal/Dockerfile
@@ -1,8 +1,8 @@
 # A test describe in the README is available to test a version update
-FROM airbyte/temporal-auto-setup:1.13.0
+FROM temporalio/auto-setup:1.20.1
 
 ENV TEMPORAL_HOME /etc/temporal
 
-COPY bin/scripts/update-and-start-temporal.sh update-and-start-temporal.sh
+COPY update-and-start-temporal.sh update-and-start-temporal.sh
 
 ENTRYPOINT ["./update-and-start-temporal.sh"]

--- a/airbyte-temporal/README.md
+++ b/airbyte-temporal/README.md
@@ -4,7 +4,7 @@ This module implements a custom version of what the Temporal autosetup image is 
 
 ## Testing a temporal migration
 
-`tools/bin/test_temporal_migration.sh` is available to test that a bump of the temporal version won't break the docker compose build. Here is what 
+`tools/bin/test-temporal-migration.sh` is available to test that a bump of the temporal version won't break the docker compose build. Here is what 
 the script does:
 - checkout master
 - build the docker image
@@ -16,29 +16,3 @@ the script does:
 - run docker compose up.
 
 At the end of the script you should be able to access a local airbyte in `localhost:8000`.
-
-## Apple Silicon (M1) Support
-
-Airbyte publishes an image called [airbyte/temporal-auto-setup](https://hub.docker.com/r/airbyte/temporal-auto-setup/tags) which is built for both
-Intel-based and ARM-based systems.
-
-This is because at the time of this writing, Temporal only offers their [temporalio/auto-setup](https://hub.docker.com/r/temporalio/auto-setup) image
-for Intel-based (amd64) systems.
-
-Airbyte re-publishes this image
-as [airbyte/temporal-auto-setup:1.13.0-amd64](https://hub.docker.com/layers/airbyte/temporal-auto-setup/1.13.0-amd64/images/sha256-46da05b202e2fa66d9c3f5af5a31b954979d8132c4f67300e884bdad8a45b94d?context=explore)
-, and also runs the `build-temporal.sh` script in this repository on an ARM-based system to build and
-publish [airbyte/temporal-auto-setup:1.13.0-arm64](https://hub.docker.com/layers/airbyte/temporal-auto-setup/1.13.0-arm64/images/sha256-05027f6a9ba658205c5e961165bb8dad55c95ae0a009eddbf491d12f3d84fe20?context=explore)
-.
-
-Finally, Airbyte creates and publishes a manifest list with both images
-as [airbyte/temporal-auto-setup:1.13.0](https://hub.docker.com/layers/airbyte/temporal-auto-setup/1.13.0/images/sha256-46da05b202e2fa66d9c3f5af5a31b954979d8132c4f67300e884bdad8a45b94d?context=explore)
-like so:
-
-```bash
-docker manifest create airbyte/temporal-auto-setup:1.13.0 \
---amend airbyte/temporal-auto-setup:1.13.0-amd64 \
---amend airbyte/temporal-auto-setup:1.13.0-arm64
-```
-
-This process will need to be replicated for any future version upgrades beyond `1.13.0`. See the [original issue](https://github.com/airbytehq/airbyte/issues/8849) for more info.

--- a/airbyte-temporal/build.gradle
+++ b/airbyte-temporal/build.gradle
@@ -1,10 +1,19 @@
-task copyScripts(type: Copy) {
-    dependsOn copyDocker
-
-    from('scripts')
-    into 'build/docker/bin/scripts'
+plugins {
+    id "io.airbyte.gradle.jvm.lib"
+    id "io.airbyte.gradle.docker"
 }
 
-tasks.named("buildDockerImage") {
-    dependsOn copyScripts
+airbyte {
+    docker {
+        imageName = "temporal"
+    }
+}
+
+def copyScripts = tasks.register("copyScripts", Copy) {
+    from('scripts')
+    into 'build/airbyte/docker/'
+}
+
+tasks.named("dockerBuildImage") {
+    dependsOn(copyScripts)
 }

--- a/airbyte-temporal/scripts/update-and-start-temporal.sh
+++ b/airbyte-temporal/scripts/update-and-start-temporal.sh
@@ -18,7 +18,7 @@ DEFAULT_NAMESPACE_RETENTION=${DEFAULT_NAMESPACE_RETENTION:-1}
 # See https://github.com/temporalio/temporal/blob/release/v1.13.x/docker/entrypoint.sh
 init_entry_point() {
   echo "Start init"
-  export BIND_ON_IP="${BIND_ON_IP:-$(hostname -i)}"
+  export BIND_ON_IP="`ip addr show dev eth0 | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\1/;t;d' | head -n 1`"
 
   if [[ "${BIND_ON_IP}" =~ ":" ]]; then
       # ipv6
@@ -47,11 +47,11 @@ update_postgres_schema() {
   CONTAINER_ALREADY_STARTED="CONTAINER_ALREADY_STARTED_PLACEHOLDER"
   if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
       touch $CONTAINER_ALREADY_STARTED
-      temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${DBNAME}"
+      temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" create
       temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" setup-schema -v 0.0
 
 
-      temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
+      temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" create
       temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
   fi
   echo "Starting to update the temporal DB"

--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/ProcessFactoryBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/ProcessFactoryBeanFactory.java
@@ -50,7 +50,7 @@ public class ProcessFactoryBeanFactory {
       throws UnknownHostException {
     final KubernetesClient fabricClient = new DefaultKubernetesClient();
     final String localIp = InetAddress.getLocalHost().getHostAddress();
-    final String kubeHeartbeatUrl = localIp + ":" + serverPort;
+    final String kubeHeartbeatUrl = localIp.contains(":") ? "[" + localIp + "]:" + serverPort : localIp + ":" + serverPort;
     return new KubeProcessFactory(workerConfigsProvider,
         kubernetesNamespace,
         fabricClient,

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -100,7 +100,7 @@ class KubePodProcessIntegrationTest {
 
   @BeforeEach
   void setup() throws Exception {
-    heartbeatUrl = getHost() + ":" + heartbeatPort;
+    heartbeatUrl = getHost().contains(":") ? "[" + localIp + "]:" + serverPort : getHost() + ":" + serverPort;
 
     fabricClient = new DefaultKubernetesClient();
 

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -100,7 +100,7 @@ class KubePodProcessIntegrationTest {
 
   @BeforeEach
   void setup() throws Exception {
-    heartbeatUrl = getHost().contains(":") ? "[" + localIp + "]:" + serverPort : getHost() + ":" + serverPort;
+    heartbeatUrl = getHost().contains(":") ? "[" + getHost() + "]:" + heartbeatPort : getHost() + ":" + heartbeatPort;
 
     fabricClient = new DefaultKubernetesClient();
 

--- a/tools/bin/test-temporal-migration.sh
+++ b/tools/bin/test-temporal-migration.sh
@@ -12,8 +12,8 @@ fi
 
 NEW_HASH="$( git rev-parse HEAD )"
 
-git checkout master
-git pull --no-rebase
+#git checkout master
+#git pull --no-rebase
 
 "$SCRIPT_DIR"/../../gradlew -p "$SCRIPT_DIR"/../.. generate-docker
 


### PR DESCRIPTION
## What
Fixes the worker for IPv6 (and network) only k8s cluster support.

## How
Fixing endpoints to support IPv6 only addresses 

## Recommended reading order
1. `x.java`
2. `y.java`

## Can this PR be safely reverted / rolled back?
Yes.

*If unsure, leave it blank.*
- [X] YES 💚
- [] NO ❌

## 🚨 User Impact 🚨
None expected.