### PR TITLE
Add support for IAM Roles with AWS Secrets Manager

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
@@ -68,24 +68,23 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
   }
 
   /**
-   * Creates a new AWSSecretManagerPersistence using the provided explicitly passed credentials.
+   * Creates a new AWSSecretManagerPersistence using the provided explicitly passed credentials. If
+   * awsAccessKey is null or empty the DefaultAWSCredentialsProviderChain is used.
    *
    * @param awsAccessKey The AWS access key.
    * @param awsSecretAccessKey The AWS secret access key.
    */
   public AWSSecretManagerPersistence(final String awsAccessKey, final String awsSecretAccessKey) {
-    checkNotNull(awsAccessKey, "awsAccessKey cannot be null, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    checkNotNull(awsSecretAccessKey,
-        "awsSecretAccessKey cannot be null, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    checkArgument(!awsAccessKey.isEmpty(),
-        "awsAccessKey cannot be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    checkArgument(!awsSecretAccessKey.isEmpty(),
-        "awsSecretAccessKey cannot be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    BasicAWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretAccessKey);
-    this.client = AWSSecretsManagerClientBuilder
-        .standard()
-        .withCredentials(new AWSStaticCredentialsProvider(credentials))
-        .build();
+    final var builder = AWSSecretsManagerClientBuilder.standard();
+
+    // If credentials are part of this config, specify them. Otherwise,
+    // let the SDK's default credential provider take over.
+    if (awsAccessKey != null && !awsSecretAccessKey.equals("")) {
+      BasicAWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretAccessKey);
+      builder.withCredentials(new AWSStaticCredentialsProvider(credentials));
+    }
+
+    this.client = builder.build();
     this.cache = new SecretCache(this.client);
   }
 


### PR DESCRIPTION
## What

Relaxes the requirement to provide an awsAccessKey and awsSecretAccessKey when using AWSSecretManagerPersistence.  When these values are not provided the AWS SDK will fallback to the default credential provider (e.g. IAM Role).

## How
Adopts a similar approach to that taken in [airbyte-config/config-models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java](https://github.com/airbytehq/airbyte-platform/blob/main/airbyte-config/config-models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java) as part of https://github.com/airbytehq/airbyte-platform/commit/37ba07b5001f825abaa2191422be7b04f72fff4d#

## Can this PR be safely reverted / rolled back?
- [X] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
The only anticipated user impact is in the event that no valid credentials are discoverable by the AWS SDK.  This would also have previously led to failure, but earlier and more explicitly in the service boot sequence.