### PR TITLE
Helm - Allow customization of WEBAPP_URL

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -61,7 +61,7 @@ data:
   TEMPORAL_HOST: {{ .Release.Name }}-temporal:{{ .Values.temporal.service.port }}
   TEMPORAL_WORKER_PORTS: 9001,9002,9003,9004,9005,9006,9007,9008,9009,9010,9011,9012,9013,9014,9015,9016,9017,9018,9019,9020,9021,9022,9023,9024,9025,9026,9027,9028,9029,9030,9031,9032,9033,9034,9035,9036,9037,9038,9039,9040
   TRACKING_STRATEGY: segment
-  WEBAPP_URL: http://{{ .Release.Name }}-airbyte-webapp-svc:{{ .Values.webapp.service.port }}
+  WEBAPP_URL: {{ .Values.webapp.url | default (printf "http://%s-airbyte-webapp-svc:%d" .Release.Name (.Values.webapp.service.port | int)) }}
   WORKER_ENVIRONMENT: kubernetes
   WORKSPACE_DOCKER_MOUNT: airbyte_workspace
   WORKSPACE_ROOT: /workspace

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -310,6 +310,9 @@ webapp:
   connector-builder-server:
     url: /connector-builder-api
 
+  ##  webapp.url Define the url the Airbyte Webapp is hosted at.
+  url: ""
+
   ##  webapp.fullstory.enabled Whether or not to enable fullstory
   fullstory:
     enabled: false


### PR DESCRIPTION
## What
This change allows setting the `WEBAPP_URL` variable from the helm chart. It solves the issue discussed in https://github.com/airbytehq/airbyte/issues/23269

Let me know what you think about it