### PR TITLE
fix(temporal): use correct property value for temporal.retention

### DIFF
--- a/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/TemporalUtils.java
+++ b/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/TemporalUtils.java
@@ -81,7 +81,7 @@ public class TemporalUtils {
                        @Value("${temporal.cloud.host}") final String temporalCloudHost,
                        @Value("${temporal.cloud.namespace}") final String temporalCloudNamespace,
                        @Value("${temporal.host}") final String temporalHost,
-                       @Property(name = "${temporal.retention}",
+                       @Property(name = "temporal.retention",
                                  defaultValue = "30") final Integer temporalRetentionInDays) {
     this.temporalCloudClientCert = temporalCloudClientCert;
     this.temporalCloudClientKey = temporalCloudClientKey;


### PR DESCRIPTION
## What
This fixes an issue with setting the default namespace retention back to the default of 30 days

Fixes: https://github.com/airbytehq/airbyte/issues/28235

## How

Use the correct `name` value of the `@Property` annotation

## Recommended reading order
1. `airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/TemporalUtils.java`

## 🚨 User Impact 🚨
Probably not