### PR TITLE
Helm: Add ability to set resources for postgresql and minio deployments

### DIFF
--- a/charts/airbyte/templates/airbyte-db.yaml
+++ b/charts/airbyte/templates/airbyte-db.yaml
@@ -53,6 +53,8 @@ spec:
           volumeMounts:
             - name: airbyte-volume-db
               mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}    
   volumeClaimTemplates:
   - metadata:
       name: airbyte-volume-db

--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -48,6 +48,8 @@ spec:
           volumeMounts:
             - name: airbyte-minio-pv-claim # must match the volume name, above
               mountPath: "/data"
+          resources:
+            {{- toYaml .Values.minio.resources | nindent 12 }}
       {{- with .Values.minio.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1,3 +1,4 @@
+---
 ### TEST FOR RELEASE WORKFLOW
 
 ## @section Global Parameters
@@ -1248,6 +1249,8 @@ temporal:
 ##  postgresql.containerSecurityContext.runAsNonRoot Ensures the container will run with a non-root user
 ##  postgresql.commonAnnotations.helm.sh/hook It will determine when the hook should be rendered
 ##  postgresql.commonAnnotations.helm.sh/hook-weight The order in which the hooks are executed. If weight is lower, it has higher priority
+##  postgresql.resources.limits [object] The resources limits for postgresql
+##  postgresql.resources.requests [object] The requested resources for postgresql
 ##
 postgresql:
   enabled: true
@@ -1268,6 +1271,23 @@ postgresql:
   commonAnnotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-1"
+
+  ## PostgreSQL resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ##  postgresql.resources.limits [object] The resources limits for postgresql
+  ##  postgresql.resources.requests [object] The requested resources for postgresql
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false
 ##  externalDatabase.host Database host
@@ -1289,11 +1309,14 @@ externalDatabase:
   port: 5432
   jdbcUrl: ""
 
+
 ## @section Logs parameters
 
 ## @section Minio chart overwrites
 ##  minio.accessKey.password Minio Access Key
 ##  minio.secretKey.password Minio Secret Key
+##  minio.resources.limits [object] The resources limits for minio
+##  minio.resources.requests [object] The requested resources for minio
 minio:
   enabled: true
 
@@ -1308,6 +1331,23 @@ minio:
     rootPassword: minio123
   storage:
     volumeClaimValue: 500Mi
+
+
+  ## Minio resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ##  minio.resources.limits [object] The resources limits for minio
+  ##  minio.resources.requests [object] The requested resources for minio
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 ## @section cron parameters
 


### PR DESCRIPTION
## What
Adds the ability for users of the [airbyte Helm chart](https://docs.airbyte.com/deploying-airbyte/on-kubernetes-via-helm) to set resources for the PostgreSQL and Minio deployments.

## How
Helm templating / values.

Doesn't set any default values, so as not to change the existing behaviour of having no resources set.

## Recommended reading order
N/A

## Can this PR be safely reverted / rolled back?
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
