### PR TITLE
Fix extraContainers in Cron helm chart

### DIFF
--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
           {{- end }}
 
         {{- if .Values.extraContainers }}
-          {{ toYaml .Values.extraContainers | nindent 6 }}
+          {{ toYaml .Values.extraContainers | nindent 8 }}
         {{- end }}
         {{- if .Values.global.extraContainers }}
           {{ toYaml .Values.global.extraContainers | nindent 8 }}


### PR DESCRIPTION
## What
If current chart is used with `extraContainers` enabled the deployment will fail with the following error message:

```
Error: YAML parse error on cron/templates/deployment.yaml: error converting YAML to JSON: yaml: line 94: did not find expected key
```

This is not a problem when global `extraContainers` is used, but if, for example, we want Cron specific sidecar containers the setup will fail.

## How
Added proper indentation to line 154.

## Can this PR be safely reverted / rolled back?

*If unsure, leave it blank.*
- [X ] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
None.
