### PR TITLE
Create secret for service account if k8s version >= 1.24

### DIFF
--- a/charts/airbyte/templates/serviceaccount.yaml
+++ b/charts/airbyte/templates/serviceaccount.yaml
@@ -12,6 +12,18 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.GitVersion -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "airbyte.serviceAccountName" . }}.service-account-token
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    kubernetes.io/service-account.name: {{ include "airbyte.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/airbyte/templates/serviceaccount.yaml
+++ b/charts/airbyte/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion -}}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/airbyte/templates/serviceaccount.yaml
+++ b/charts/airbyte/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion -}}
+{{ if and (semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion) .Values.serviceAccount.create_secret -}}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -174,6 +174,7 @@ fullnameOverride: ""
 ##
 serviceAccount:
   create: true
+  create_secret: false
   annotations: {}
   name: *service-account-name
 


### PR DESCRIPTION
## What
This PR adds the capability to create the service account secret, during helm install, if the kubernetes cluster version is >= 1.24
Since k8s v1.24 secrets API objects containing service account tokens are no longer auto-generated.
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes

## How
Create a Secret API object linked to the service account if k8s version is >= 1.24.0

## Can this PR be safely reverted / rolled back?
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
If the user manually created the Secret object before this change, the helm install/upgrade command will fail.
