### PR TITLE
fix: upgrade temporal to latest 1.20.x

### DIFF
--- a/airbyte-temporal/Dockerfile
+++ b/airbyte-temporal/Dockerfile
@@ -1,5 +1,5 @@
 # A test describe in the README is available to test a version update
-FROM temporalio/auto-setup:1.20.1
+FROM temporalio/auto-setup:1.20.4
 
 ENV TEMPORAL_HOME /etc/temporal
 


### PR DESCRIPTION
## What
Upgrade for security purpose

better would be to upgrade to latest release 1.22.x but i don't know if it will breaks something

## How
Upgrade

## Can this PR be safely reverted / rolled back?

- [X] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
No
