### PR TITLE
fix: move external default docker images to latest stable

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -203,9 +203,9 @@ public class EnvConfigs implements Configs {
   private static final String SECRET_STORE_GCP_CREDENTIALS = "SECRET_STORE_GCP_CREDENTIALS";
   private static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
   private static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
-  private static final String DEFAULT_JOB_KUBE_SOCAT_IMAGE = "alpine/socat:1.7.4.4-r0";
-  private static final String DEFAULT_JOB_KUBE_BUSYBOX_IMAGE = "busybox:1.35";
-  private static final String DEFAULT_JOB_KUBE_CURL_IMAGE = "curlimages/curl:7.87.0";
+  private static final String DEFAULT_JOB_KUBE_SOCAT_IMAGE = "alpine/socat:latest";
+  private static final String DEFAULT_JOB_KUBE_BUSYBOX_IMAGE = "busybox:stable-glibc";
+  private static final String DEFAULT_JOB_KUBE_CURL_IMAGE = "curlimages/curl:latest";
   private static final int DEFAULT_DATABASE_INITIALIZATION_TIMEOUT_MS = 60 * 1000;
   private static final long DEFAULT_MAX_SPEC_WORKERS = 5;
   private static final long DEFAULT_MAX_CHECK_WORKERS = 5;


### PR DESCRIPTION
## What
Upgrade external docker image to latest stable release
better to have sane/secure defaults

## Can this PR be safely reverted / rolled back?

- [X] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
No
