### PR TITLE
Helm INTERNAL_API_URL fix

### DIFF
--- a/charts/airbyte-api-server/templates/deployment.yaml
+++ b/charts/airbyte-api-server/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: {{ .Release.Name }}-airbyte-env
-              key: INTERNAL_API_HOST
+              key: INTERNAL_API_URL
         - name: AIRBYTE_API_HOST
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -25,6 +25,7 @@ data:
   GCS_LOG_BUCKET: {{ .Values.global.logs.gcs.bucket | quote }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "airbyte.gcpLogCredentialsPath" . | quote }}
   INTERNAL_API_HOST: {{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}
+  INTERNAL_API_URL: http://{{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}
 {{- if eq .Values.global.edition "pro" }}
   KEYCLOAK_INTERNAL_HOST: {{ .Release.Name }}-airbyte-keycloak-svc:{{ .Values.keycloak.service.port }}
   KEYCLOAK_PORT: {{ .Values.keycloak.service.port | quote }}


### PR DESCRIPTION
## What
It fixes the Airbyte API Server helm chart.

## How
We added an extra env variable for the Airbyte internal API URL prefixed with `http://`.

## Recommended reading order

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [X] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
