### PR TITLE
Fix inaccessible GCS bucket storage

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -70,7 +70,7 @@ global:
     ##  logs.s3.bucketRegion Region of the bucket (must be empty if using minio)
     s3:
       enabled: false
-      bucket: airbyte-dev-logs
+      bucket: ""
       bucketRegion: ""
 
     ## Google Cloud Storage (GCS) Log Location Configuration


### PR DESCRIPTION
## What

GCS storage is unusable when using chart version `0.49.6`.
Issue is described here as well: https://github.com/airbytehq/airbyte/issues/25906

## How

It seems that the worker would still pickup the default s3 "airbyte-dev-logs" bucket when available.
Setting it to an empty string fixed the issue.

## Recommended reading order
1. `values.yml`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
