### PR TITLE
Increase BUFFER_READ_AHEAD_LIMIT

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactory.java
@@ -67,7 +67,7 @@ public class VersionedAirbyteStreamFactory<T> implements AirbyteStreamFactory {
   // Given that BufferedReader::reset fails if we try to reset if we go past its buffer size, this
   // buffer has to be big enough to contain our longest spec and whatever messages get emitted before
   // the SPEC.
-  private static final int BUFFER_READ_AHEAD_LIMIT = 32000;
+  private static final int BUFFER_READ_AHEAD_LIMIT = 2 * 1024 * 1024; // 2 megabytes
   private static final int MESSAGES_LOOK_AHEAD_FOR_DETECTION = 10;
   private static final String TYPE_FIELD_NAME = "type";
   private static final int MAXIMUM_CHARACTERS_ALLOWED = 5_000_000;


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/25015

## How
Increases the `BUFFER_READ_AHEAD_LIMIT` to a reasonable size.

## Recommended reading order
1. `VersionedAirbyteStreamFactory.java`

## Can this PR be safely reverted / rolled back?
- [ ] YES 💚
- [X] NO ❌

