### PR TITLE
remove replica count on worker when hpa enabled

### DIFF
--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     {{ toYaml (mergeOverwrite .Values.extraLabels .Values.global.extraLabels) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if eq .Values.hpa.enabled false}}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "airbyte.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## What

The current `hpa` parameter in the `values.yml` doesn't actually do anything for the worker. Worse, when you try to apply your own HPA configuration, the `replicaCount` blocks the scaling altogether.

I'm not proposing extra config for the hpa, simply the possibility to remove it if you use your own

Relates to this: https://github.com/airbytehq/airbyte/issues/25141

## How

Added an if/else removing `spec.replicas` on the worker deployment if `worker.hpa.enabled` is true 

## Recommended reading order
1. `x.java`
2. `y.java`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [ ] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
