### PR TITLE
fix: update internal api host

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -24,7 +24,7 @@ data:
   DB_DOCKER_MOUNT: airbyte_db
   GCS_LOG_BUCKET: {{ .Values.global.logs.gcs.bucket | quote }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "airbyte.gcpLogCredentialsPath" . | quote }}
-  INTERNAL_API_HOST: {{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}
+  INTERNAL_API_HOST: http://{{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}
 {{- if eq (index .Values "workload-api-server" "enabled") true }}
   # Temporary conditional for OSS deploys.  Eventually, the workload-api will be present in OSS deploys and the else
   # block can be removed


### PR DESCRIPTION
## What
Fixing the time-out error while using the terraform airbyte provider 
```
2023-12-05 08:45:22 [1;31mERROR[m i.m.h.s.RouteExecutor(logException):444 - Unexpected error occurred: No available services for ID: data-dev-airbyte-airbyte-server-svc:8001
io.micronaut.discovery.exceptions.NoAvailableServiceException: No available services for ID: data-dev-airbyte-airbyte-server-svc:8001
```

## How
By adding `http://` 


## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [X] YES 💚
- [] NO ❌

Relates to:
- https://github.com/airbytehq/airbyte/issues/29506 
- https://github.com/airbytehq/terraform-provider-airbyte/issues/24
