### PR TITLE
fix(chart): use http scheme for INTERNAL_API_HOST

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -24,7 +24,7 @@ data:
   DB_DOCKER_MOUNT: airbyte_db
   GCS_LOG_BUCKET: {{ .Values.global.logs.gcs.bucket | quote }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "airbyte.gcpLogCredentialsPath" . | quote }}
-  INTERNAL_API_HOST: {{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}
+  INTERNAL_API_HOST: http://{{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}
 {{- if eq (index .Values "workload-api-server" "enabled") true }}
   # Temporary conditional for OSS deploys.  Eventually, the workload-api will be present in OSS deploys and the else
   # block can be removed


### PR DESCRIPTION
## What

The current chart doesn't use a scheme for INTERNAL_API_HOST causing the api-server fail to reach the internal config API.

## How

This fix adds an explicit http:// prefix to the value of INTERNAL_API_HOST in the configmap.

## Recommended reading order
1. `charts/airbyte/templates/env-configmap.yaml`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨

None
