### PR TITLE
feat(api): Idempotent Resource Creation

### DIFF
--- a/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/mappers/ConnectionCreateMapper.kt
+++ b/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/mappers/ConnectionCreateMapper.kt
@@ -36,6 +36,7 @@ object ConnectionCreateMapper {
     connectionCreateOss.sourceId = connectionCreateRequest.sourceId
     connectionCreateOss.destinationId = connectionCreateRequest.destinationId
     connectionCreateOss.name = connectionCreateRequest.name
+    connectionCreateOss.idempotencyKey = connectionCreateRequest.idempotencyKey
     connectionCreateOss.nonBreakingChangesPreference =
       ConnectionHelper.convertNonBreakingSchemaUpdatesBehaviorEnum(
         connectionCreateRequest.nonBreakingSchemaUpdatesBehavior,

--- a/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/DestinationService.kt
+++ b/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/DestinationService.kt
@@ -115,6 +115,7 @@ class DestinationServiceImpl(private val configApiClient: ConfigApiClient, priva
     destinationCreateOss.destinationDefinitionId = destinationDefinitionId
     destinationCreateOss.workspaceId = destinationCreateRequest.workspaceId
     destinationCreateOss.connectionConfiguration = destinationCreateRequest.configuration
+    destinationCreateOss.idempotencyKey = destinationCreateRequest.idempotencyKey
 
     val response =
       try {

--- a/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/SourceService.kt
+++ b/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/SourceService.kt
@@ -122,6 +122,7 @@ open class SourceServiceImpl(
     sourceCreateOss.workspaceId = sourceCreateRequest.workspaceId
     sourceCreateOss.connectionConfiguration = sourceCreateRequest.configuration
     sourceCreateOss.secretId = sourceCreateRequest.secretId
+    sourceCreateOss.idempotencyKey = sourceCreateRequest.idempotencyKey
 
     val response =
       try {

--- a/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/WorkspaceService.kt
+++ b/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/WorkspaceService.kt
@@ -136,7 +136,7 @@ open class WorkspaceServiceImpl(
     authorization: String?,
     userInfo: String?,
   ): WorkspaceResponse {
-    val workspaceCreate = WorkspaceCreate().name(workspaceCreateRequest.name)
+    val workspaceCreate = WorkspaceCreate().name(workspaceCreateRequest.name).idempotencyKey(workspaceCreateRequest.idempotencyKey)
     val workspaceReadHttpResponse =
       try {
         configApiClient.createWorkspace(workspaceCreate, authorization, userInfo)

--- a/airbyte-api/src/main/openapi/api.yaml
+++ b/airbyte-api/src/main/openapi/api.yaml
@@ -1221,6 +1221,8 @@ components:
           $ref: "#/components/schemas/NonBreakingSchemaUpdatesBehaviorEnum"
         status:
           $ref: "#/components/schemas/ConnectionStatusEnum"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     ConnectionPatchRequest:
       type: object
       properties:
@@ -1299,6 +1301,8 @@ components:
         secretId:
           description: Optional secretID obtained through the public API OAuth redirect flow.
           type: string
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
       x-implements: io.airbyte.api.common.ConfigurableActor
     SourcePutRequest:
       required:
@@ -1586,6 +1590,8 @@ components:
           type: string
         configuration:
           $ref: "#/components/schemas/DestinationConfiguration"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
       x-implements: io.airbyte.api.common.ConfigurableActor
     DestinationPatchRequest:
       type: object
@@ -1614,6 +1620,8 @@ components:
         name:
           description: Name of the workspace
           type: string
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     WorkspaceUpdateRequest:
       required:
         - name
@@ -1811,3 +1819,8 @@ components:
       enum:
         - source
         - destination
+    IdempotencyKey:
+      type: string
+      format: uuid
+      description: |
+        An optional UUID that can be provided in a create request to prevent creating duplicates of the same resource

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4428,6 +4428,8 @@ components:
             $ref: "#/components/schemas/WebhookConfigWrite"
         organizationId:
           $ref: "#/components/schemas/OrganizationId"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     WorkspaceCreateWithId:
       type: object
       required:
@@ -4464,6 +4466,8 @@ components:
             $ref: "#/components/schemas/WebhookConfigWrite"
         organizationId:
           $ref: "#/components/schemas/OrganizationId"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     WebhookConfigWrite:
       type: object
       properties:
@@ -4997,6 +5001,8 @@ components:
           type: string
         resourceRequirements:
           $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     SourceDefinitionUpdate:
       type: object
       description: Update the SourceDefinition. Currently, the only allowed attribute to update is the default docker image version.
@@ -5090,6 +5096,8 @@ components:
           $ref: "#/components/schemas/ScopeType"
         sourceDefinition:
           $ref: "#/components/schemas/SourceDefinitionCreate"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     SourceDefinitionIdWithWorkspaceId:
       type: object
       required:
@@ -5280,6 +5288,8 @@ components:
         secretId:
           example: "airbyte_oauth_workspace_0509f049-d671-48cb-8105-0a23d47e6db6_secret_e0d38206-034e-4d75-9d21-da5a99b02826_v1"
           type: string
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     SourceDiscoverSchemaRequestBody:
       type: object
       required:
@@ -5478,6 +5488,8 @@ components:
           type: string
         resourceRequirements:
           $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     DestinationDefinitionUpdate:
       type: object
       required:
@@ -5558,6 +5570,8 @@ components:
           $ref: "#/components/schemas/ScopeId"
         scopeType:
           $ref: "#/components/schemas/ScopeType"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     DestinationDefinitionIdWithWorkspaceId:
       type: object
       required:
@@ -5657,6 +5671,8 @@ components:
           $ref: "#/components/schemas/DestinationDefinitionId"
         connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfiguration"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     DestinationUpdate:
       type: object
       required:
@@ -5969,6 +5985,8 @@ components:
           type: boolean
         nonBreakingChangesPreference:
           $ref: "#/components/schemas/NonBreakingChangesPreference"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     WebBackendConnectionCreate:
       type: object
       required:
@@ -6020,6 +6038,8 @@ components:
           $ref: "#/components/schemas/Geography"
         nonBreakingChangesPreference:
           $ref: "#/components/schemas/NonBreakingChangesPreference"
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     ConnectionStateCreateOrUpdate:
       type: object
       required:
@@ -6687,6 +6707,8 @@ components:
           type: boolean
         orgLevelBilling:
           type: boolean
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     OrganizationRead:
       type: object
       required:
@@ -7038,7 +7060,8 @@ components:
         news:
           type: boolean
           default: false
-
+        idempotencyKey:
+          $ref: "#/components/schemas/IdempotencyKey"
     UserGetOrCreateByAuthIdResponse:
       type: object
       required:
@@ -9159,7 +9182,11 @@ components:
       properties:
         access_token:
           type: string
-
+    IdempotencyKey:
+      type: string
+      format: uuid
+      description: |
+        An optional UUID that can be provided in a create request to prevent creating duplicates of the same resource
   responses:
     NotFoundResponse:
       description: Object with given id was not found.

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderTest.java
@@ -95,7 +95,7 @@ class BootloaderTest {
 
   // ⚠️ This line should change with every new migration to show that you meant to make a new
   // migration to the prod database
-  private static final String CURRENT_CONFIGS_MIGRATION_VERSION = "0.50.33.015";
+  private static final String CURRENT_CONFIGS_MIGRATION_VERSION = "0.50.33.016";
   private static final String CURRENT_JOBS_MIGRATION_VERSION = "0.50.4.001";
   private static final String CDK_VERSION = "1.2.3";
 

--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/OrganizationsHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/OrganizationsHandler.java
@@ -66,6 +66,13 @@ public class OrganizationsHandler {
 
   public OrganizationRead createOrganization(final OrganizationCreateRequestBody organizationCreateRequestBody)
       throws IOException {
+    final UUID idempotencyKey = organizationCreateRequestBody.getIdempotencyKey();
+    if (idempotencyKey != null) {
+      final Optional<Organization> found = organizationPersistence.getOrganizationByIdempotencyKey(idempotencyKey);
+      if (found.isPresent()) {
+        return buildOrganizationRead(found.get());
+      }
+    }
     final String organizationName = organizationCreateRequestBody.getOrganizationName();
     final String email = organizationCreateRequestBody.getEmail();
     final UUID userId = organizationCreateRequestBody.getUserId();

--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/UserHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/UserHandler.java
@@ -117,7 +117,15 @@ public class UserHandler {
         .withStatus(Enums.convertTo(userCreate.getStatus(), User.Status.class))
         .withCompanyName(userCreate.getCompanyName())
         .withEmail(userCreate.getEmail())
-        .withNews(userCreate.getNews());
+        .withNews(userCreate.getNews())
+        .withIdempotencyKey(userCreate.getIdempotencyKey());
+    final UUID idempotencyKey = userCreate.getIdempotencyKey();
+    if (idempotencyKey != null) {
+      Optional<User> found = userPersistence.getUserByIdempotencyKey(idempotencyKey);
+      if (found.isPresent()) {
+        return buildUserRead(found.get());
+      }
+    }
     userPersistence.writeUser(user);
     return buildUserRead(userId);
   }

--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
@@ -738,6 +738,7 @@ public class WebBackendConnectionsHandler {
     connectionCreate.sourceCatalogId(webBackendConnectionCreate.getSourceCatalogId());
     connectionCreate.geography(webBackendConnectionCreate.getGeography());
     connectionCreate.nonBreakingChangesPreference(webBackendConnectionCreate.getNonBreakingChangesPreference());
+    connectionCreate.idempotencyKey(webBackendConnectionCreate.getIdempotencyKey());
 
     return connectionCreate;
   }

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -56,6 +56,7 @@ import io.airbyte.config.init.SupportStateUpdater;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.specs.RemoteDefinitionsProvider;
+import io.airbyte.data.services.DestinationService;
 import io.airbyte.featureflag.DestinationDefinition;
 import io.airbyte.featureflag.FeatureFlagClient;
 import io.airbyte.featureflag.HideActorDefinitionFromList;
@@ -102,6 +103,8 @@ class DestinationDefinitionsHandlerTest {
   private UUID organizationId;
   private FeatureFlagClient featureFlagClient;
 
+  private DestinationService destinationService;
+
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
@@ -118,6 +121,7 @@ class DestinationDefinitionsHandlerTest {
     workspaceId = UUID.randomUUID();
     organizationId = UUID.randomUUID();
     featureFlagClient = mock(TestClient.class);
+    destinationService = mock(DestinationService.class);
     destinationDefinitionsHandler = new DestinationDefinitionsHandler(
         configRepository,
         uuidSupplier,
@@ -125,7 +129,8 @@ class DestinationDefinitionsHandlerTest {
         remoteDefinitionsProvider,
         destinationHandler,
         supportStateUpdater,
-        featureFlagClient);
+        featureFlagClient,
+        destinationService);
   }
 
   private StandardDestinationDefinition generateDestinationDefinition() {

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SourceDefinitionsHandlerTest.java
@@ -57,6 +57,7 @@ import io.airbyte.config.init.SupportStateUpdater;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.specs.RemoteDefinitionsProvider;
+import io.airbyte.data.services.SourceService;
 import io.airbyte.featureflag.FeatureFlagClient;
 import io.airbyte.featureflag.HideActorDefinitionFromList;
 import io.airbyte.featureflag.Multi;
@@ -99,6 +100,7 @@ class SourceDefinitionsHandlerTest {
   private UUID workspaceId;
   private UUID organizationId;
   private FeatureFlagClient featureFlagClient;
+  private SourceService sourceService;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -114,9 +116,10 @@ class SourceDefinitionsHandlerTest {
     sourceDefinition = generateSourceDefinition();
     sourceDefinitionVersion = generateVersionFromSourceDefinition(sourceDefinition);
     featureFlagClient = mock(TestClient.class);
+    sourceService = mock(SourceService.class);
     sourceDefinitionsHandler =
         new SourceDefinitionsHandler(configRepository, uuidSupplier, actorDefinitionHandlerHelper, remoteDefinitionsProvider, sourceHandler,
-            supportStateUpdater, featureFlagClient);
+            supportStateUpdater, featureFlagClient, sourceService);
   }
 
   private StandardSourceDefinition generateSourceDefinition() {

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -621,6 +621,7 @@ class WebBackendConnectionsHandlerTest {
     final UUID newDestinationId = UUID.randomUUID();
     final UUID newOperationId = UUID.randomUUID();
     final UUID sourceCatalogId = UUID.randomUUID();
+    final UUID idempotencyKey = UUID.randomUUID();
     final WebBackendConnectionCreate input = new WebBackendConnectionCreate()
         .name("testConnectionCreate")
         .namespaceDefinition(Enums.convertTo(standardSync.getNamespaceDefinition(), NamespaceDefinitionType.class))
@@ -634,7 +635,8 @@ class WebBackendConnectionsHandlerTest {
         .syncCatalog(catalog)
         .sourceCatalogId(sourceCatalogId)
         .geography(Geography.US)
-        .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE);
+        .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
+        .idempotencyKey(idempotencyKey);
 
     final List<UUID> operationIds = List.of(newOperationId);
 
@@ -651,7 +653,8 @@ class WebBackendConnectionsHandlerTest {
         .syncCatalog(catalog)
         .sourceCatalogId(sourceCatalogId)
         .geography(Geography.US)
-        .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE);
+        .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
+        .idempotencyKey(idempotencyKey);
 
     final ConnectionCreate actual = WebBackendConnectionsHandler.toConnectionCreate(input, operationIds);
 
@@ -713,7 +716,7 @@ class WebBackendConnectionsHandlerTest {
         Set.of("name", "namespaceDefinition", "namespaceFormat", "prefix", "sourceId", "destinationId", "operationIds",
             "addOperationIdsItem", "removeOperationIdsItem", "syncCatalog", "schedule", "scheduleType", "scheduleData",
             "status", "resourceRequirements", "sourceCatalogId", "geography", "nonBreakingChangesPreference", "notifySchemaChanges",
-            "notifySchemaChangesByEmail");
+            "notifySchemaChangesByEmail", "idempotencyKey");
 
     final Set<String> methods = Arrays.stream(ConnectionCreate.class.getMethods())
         .filter(method -> method.getReturnType() == ConnectionCreate.class)

--- a/airbyte-config/config-models/src/main/resources/types/DestinationConnection.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/DestinationConnection.yaml
@@ -37,3 +37,5 @@ properties:
       if not set or false, the configuration is active. if true, then this
       configuration is permanently off.
     type: boolean
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/IdempotencyKey.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/IdempotencyKey.yaml
@@ -1,0 +1,7 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/IdempotencyKey.yaml
+title: IdempotencyKey
+description: A UUID that can be provided in a request to prevent executing duplicate operation
+type: string
+format: uuid

--- a/airbyte-config/config-models/src/main/resources/types/Organization.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/Organization.yaml
@@ -31,3 +31,5 @@ properties:
   ssoRealm:
     description: This organization's SSO realm, if set via an SsoConfig
     type: string
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/SourceConnection.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/SourceConnection.yaml
@@ -37,3 +37,5 @@ properties:
       if not set or false, the configuration is active. if true, then this
       configuration is permanently off.
     type: boolean
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -34,3 +34,5 @@ properties:
     default: false
   resourceRequirements:
     "$ref": ActorDefinitionResourceRequirements.yaml
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -44,3 +44,5 @@ properties:
   maxSecondsBetweenMessages:
     description: Number of seconds allowed between 2 airbyte protocol messages. The source will timeout if this delay is reach
     type: integer
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
@@ -136,3 +136,5 @@ properties:
       - disable # disable the connection, pausing the sync
       - propagate_columns # Auto propagate schema change for existing streams
       - propagate_fully # Auto propagate schema change for all streams including the new ones
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
@@ -61,3 +61,5 @@ properties:
   organizationId:
     type: string
     format: uuid
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-models/src/main/resources/types/User.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/User.yaml
@@ -52,3 +52,5 @@ properties:
     type: object
     description: metadata information required from frontend UI
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  idempotencyKey:
+    $ref: "IdempotencyKey.yaml"

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/OrganizationPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/OrganizationPersistence.java
@@ -68,6 +68,27 @@ public class OrganizationPersistence {
     return Optional.of(createOrganizationFromRecord(result.get(0)));
   }
 
+  /**
+   * Retrieves an organization based on the specified idempotency key.
+   *
+   * @param idempotencyKey The idempotency key to search for an organization.
+   * @return An Optional that may contain the organization with the specified idempotency key, or
+   *         empty if not found.
+   */
+  public Optional<Organization> getOrganizationByIdempotencyKey(UUID idempotencyKey) throws IOException {
+    final Result<Record> result = database.query(ctx -> ctx
+        .select(asterisk())
+        .from(ORGANIZATION)
+        .leftJoin(SSO_CONFIG).on(ORGANIZATION.ID.eq(SSO_CONFIG.ORGANIZATION_ID))
+        .where(ORGANIZATION.IDEMPOTENCY_KEY.eq(idempotencyKey)).fetch());
+
+    if (result.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(createOrganizationFromRecord(result.get(0)));
+  }
+
   public Optional<Organization> getOrganizationByWorkspaceId(final UUID workspaceId) throws IOException {
     final Result<Record> result = database.query(ctx -> ctx
         .select(asterisk())

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/UserPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/UserPersistence.java
@@ -56,6 +56,7 @@ public class UserPersistence {
    */
   public void writeUser(final User user) throws IOException {
     database.transaction(ctx -> {
+      final UUID idempotencyKey = user.getIdempotencyKey();
       final OffsetDateTime timestamp = OffsetDateTime.now();
       final boolean isExistingConfig = ctx.fetchExists(select()
           .from(USER)
@@ -93,6 +94,7 @@ public class UserPersistence {
             .set(USER.NEWS, user.getNews())
             .set(USER.CREATED_AT, timestamp)
             .set(USER.UPDATED_AT, timestamp)
+            .set(USER.IDEMPOTENCY_KEY, idempotencyKey)
             .execute();
       }
       return null;

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/UserPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/UserPersistence.java
@@ -110,6 +110,24 @@ public class UserPersistence {
   }
 
   /**
+   * Retrieves a user based on the provided idempotency key.
+   *
+   * @param idempotencyKey The idempotency key used to identify the user.
+   * @return user if found
+   */
+  public Optional<User> getUserByIdempotencyKey(final UUID idempotencyKey) throws IOException {
+    final Result<Record> result = database.query(ctx -> ctx
+        .select(asterisk())
+        .from(USER)
+        .where(USER.IDEMPOTENCY_KEY.eq(idempotencyKey)).fetch());
+    if (result.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(createUserFromRecord(result.get(0)));
+  }
+
+  /**
    * Get User.
    *
    * @param userId internal user id

--- a/airbyte-data/src/main/java/io/airbyte/data/services/ConnectionService.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/ConnectionService.java
@@ -15,6 +15,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -26,6 +27,8 @@ public interface ConnectionService {
   void deleteStandardSync(UUID syncId) throws IOException;
 
   StandardSync getStandardSync(UUID connectionId) throws JsonValidationException, IOException, ConfigNotFoundException;
+
+  Optional<StandardSync> getStandardSyncByIdempotencyKey(UUID idempotencyKey) throws IOException;
 
   void writeStandardSync(StandardSync standardSync) throws IOException;
 

--- a/airbyte-data/src/main/java/io/airbyte/data/services/DestinationService.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/DestinationService.java
@@ -16,6 +16,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -25,6 +26,8 @@ public interface DestinationService {
 
   StandardDestinationDefinition getStandardDestinationDefinition(UUID destinationDefinitionId)
       throws JsonValidationException, IOException, ConfigNotFoundException;
+
+  Optional<StandardDestinationDefinition> getStandardDestinationDefinitionByIdempotencyKey(UUID idempotencyKey) throws IOException;
 
   StandardDestinationDefinition getDestinationDefinitionFromDestination(UUID destinationId);
 
@@ -43,6 +46,8 @@ public interface DestinationService {
       throws IOException, JsonValidationException, ConfigNotFoundException;
 
   DestinationConnection getDestinationConnection(UUID destinationId) throws JsonValidationException, IOException, ConfigNotFoundException;
+
+  Optional<DestinationConnection> getDestinationConnectionByIdempotencyKey(UUID idempotencyKey) throws IOException;
 
   void writeDestinationConnectionNoSecrets(DestinationConnection partialDestination) throws IOException;
 

--- a/airbyte-data/src/main/java/io/airbyte/data/services/SourceService.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/SourceService.java
@@ -16,6 +16,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -24,6 +25,8 @@ import java.util.UUID;
 public interface SourceService {
 
   StandardSourceDefinition getStandardSourceDefinition(UUID sourceDefinitionId) throws JsonValidationException, IOException, ConfigNotFoundException;
+
+  Optional<StandardSourceDefinition> getStandardSourceDefinitionByIdempotencyKey(UUID idempotencyKey) throws IOException;
 
   StandardSourceDefinition getSourceDefinitionFromSource(UUID sourceId);
 
@@ -40,6 +43,8 @@ public interface SourceService {
   void updateStandardSourceDefinition(StandardSourceDefinition sourceDefinition) throws IOException, JsonValidationException, ConfigNotFoundException;
 
   SourceConnection getSourceConnection(UUID sourceId) throws JsonValidationException, ConfigNotFoundException, IOException;
+
+  Optional<SourceConnection> getSourceConnectionByIdempotencyKey(UUID idempotencyKey) throws IOException;
 
   void writeSourceConnectionNoSecrets(SourceConnection partialSource) throws IOException;
 

--- a/airbyte-data/src/main/java/io/airbyte/data/services/WorkspaceService.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/WorkspaceService.java
@@ -29,6 +29,8 @@ public interface WorkspaceService {
 
   StandardWorkspace getWorkspaceBySlug(String slug, boolean includeTombstone) throws IOException, ConfigNotFoundException;
 
+  Optional<StandardWorkspace> getWorkspaceByIdempotencyKey(UUID idempotencyKey) throws IOException, ConfigNotFoundException;
+
   List<StandardWorkspace> listStandardWorkspaces(boolean includeTombstone) throws IOException;
 
   List<StandardWorkspace> listAllWorkspacesPaginated(ResourcesQueryPaginated resourcesQueryPaginated) throws IOException;

--- a/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/ConnectionServiceJooqImpl.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/ConnectionServiceJooqImpl.java
@@ -623,6 +623,7 @@ public class ConnectionServiceJooqImpl implements ConnectionService {
   }
 
   private void writeStandardSync(final StandardSync standardSync, final DSLContext ctx) {
+    final UUID idempotencyKey = standardSync.getIdempotencyKey();
     final OffsetDateTime timestamp = OffsetDateTime.now();
     final boolean isExistingConfig = ctx.fetchExists(select()
         .from(CONNECTION)
@@ -713,6 +714,7 @@ public class ConnectionServiceJooqImpl implements ConnectionService {
           .set(CONNECTION.BREAKING_CHANGE, standardSync.getBreakingChange())
           .set(CONNECTION.CREATED_AT, timestamp)
           .set(CONNECTION.UPDATED_AT, timestamp)
+          .set(CONNECTION.IDEMPOTENCY_KEY, idempotencyKey)
           .execute();
 
       updateOrCreateNotificationConfiguration(standardSync, timestamp, ctx);

--- a/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/DestinationServiceJooqImpl.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/DestinationServiceJooqImpl.java
@@ -120,6 +120,15 @@ public class DestinationServiceJooqImpl implements DestinationService {
         .orElseThrow(() -> new ConfigNotFoundException(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destinationDefinitionId));
   }
 
+  @Override
+  public Optional<StandardDestinationDefinition> getStandardDestinationDefinitionByIdempotencyKey(UUID idempotencyKey) throws IOException {
+    final Result<Record> result = database.query(ctx -> {
+      final SelectJoinStep<Record> query = ctx.select(asterisk()).from(ACTOR_DEFINITION);
+      return query.where(ACTOR_DEFINITION.ACTOR_TYPE.eq(ActorType.destination)).and(ACTOR_DEFINITION.IDEMPOTENCY_KEY.eq(idempotencyKey)).fetch();
+    });
+    return result.stream().findFirst().map(DbConverter::buildStandardDestinationDefinition);
+  }
+
   /**
    * Get destination definition form destination.
    *
@@ -263,6 +272,15 @@ public class DestinationServiceJooqImpl implements DestinationService {
     return listDestinationQuery(Optional.of(destinationId))
         .findFirst()
         .orElseThrow(() -> new ConfigNotFoundException(ConfigSchema.DESTINATION_CONNECTION, destinationId));
+  }
+
+  @Override
+  public Optional<DestinationConnection> getDestinationConnectionByIdempotencyKey(UUID idempotencyKey) throws IOException {
+    final Result<Record> result = database.query(ctx -> {
+      final SelectJoinStep<Record> query = ctx.select(asterisk()).from(ACTOR);
+      return query.where(ACTOR.ACTOR_TYPE.eq(ActorType.destination)).and(ACTOR.IDEMPOTENCY_KEY.eq(idempotencyKey)).fetch();
+    });
+    return result.stream().findFirst().map(DbConverter::buildDestinationConnection);
   }
 
   /**

--- a/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/OrganizationServiceJooqImpl.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/OrganizationServiceJooqImpl.java
@@ -60,6 +60,7 @@ public class OrganizationServiceJooqImpl implements OrganizationService {
   @Override
   public void writeOrganization(final Organization organization) throws IOException {
     database.transaction(ctx -> {
+      final UUID idempotencyKey = organization.getIdempotencyKey();
       final OffsetDateTime timestamp = OffsetDateTime.now();
       final boolean isExistingConfig = ctx.fetchExists(select()
           .from(ORGANIZATION)
@@ -86,6 +87,7 @@ public class OrganizationServiceJooqImpl implements OrganizationService {
             .set(WORKSPACE.UPDATED_AT, timestamp)
             .set(ORGANIZATION.PBA, organization.getPba())
             .set(ORGANIZATION.ORG_LEVEL_BILLING, organization.getOrgLevelBilling())
+            .set(ORGANIZATION.IDEMPOTENCY_KEY, idempotencyKey)
             .execute();
       }
       return null;

--- a/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/WorkspaceServiceJooqImpl.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/WorkspaceServiceJooqImpl.java
@@ -155,6 +155,24 @@ public class WorkspaceServiceJooqImpl implements WorkspaceService {
   }
 
   /**
+   * Retrieves the workspace corresponding to the provided idempotency key.
+   *
+   * @param idempotencyKey The idempotency key used to identify the workspace.
+   * @return workspace
+   * @throws IOException - you never know when you IO
+   * @throws ConfigNotFoundException - throws if no source with that id can be found.
+   */
+  @Override
+  public Optional<StandardWorkspace> getWorkspaceByIdempotencyKey(UUID idempotencyKey) throws IOException {
+    final Result<Record> result;
+    result = database.query(ctx -> ctx.select(WORKSPACE.asterisk())
+        .from(WORKSPACE)
+        .where(WORKSPACE.IDEMPOTENCY_KEY.eq(idempotencyKey))).fetch();
+
+    return result.stream().findFirst().map(DbConverter::buildStandardWorkspace);
+  }
+
+  /**
    * List workspaces.
    *
    * @param includeTombstone include tombstoned workspaces

--- a/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/WorkspaceServiceJooqImpl.java
+++ b/airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/WorkspaceServiceJooqImpl.java
@@ -270,6 +270,7 @@ public class WorkspaceServiceJooqImpl implements WorkspaceService {
   public void writeStandardWorkspaceNoSecrets(final StandardWorkspace workspace) throws JsonValidationException, IOException {
     database.transaction(ctx -> {
       final OffsetDateTime timestamp = OffsetDateTime.now();
+      final UUID idempotencyKey = workspace.getIdempotencyKey();
       final boolean isExistingConfig = ctx.fetchExists(select()
           .from(WORKSPACE)
           .where(WORKSPACE.ID.eq(workspace.getWorkspaceId())));
@@ -325,6 +326,7 @@ public class WorkspaceServiceJooqImpl implements WorkspaceService {
             .set(WORKSPACE.ORGANIZATION_ID, workspace.getOrganizationId())
             .set(WORKSPACE.WEBHOOK_OPERATION_CONFIGS, workspace.getWebhookOperationConfigs() == null ? null
                 : JSONB.valueOf(Jsons.serialize(workspace.getWebhookOperationConfigs())))
+            .set(WORKSPACE.IDEMPOTENCY_KEY, idempotencyKey)
             .execute();
       }
       return null;

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_50_33_016__AddIdempotencyKeys.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_50_33_016__AddIdempotencyKeys.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import static io.airbyte.db.instance.DatabaseConstants.CONNECTION_TABLE;
+import static io.airbyte.db.instance.DatabaseConstants.ORGANIZATION_TABLE;
+import static io.airbyte.db.instance.DatabaseConstants.USER_TABLE;
+import static io.airbyte.db.instance.DatabaseConstants.WORKSPACE_TABLE;
+
+import java.util.UUID;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jetbrains.annotations.NotNull;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_50_33_016__AddIdempotencyKeys extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_50_33_016__AddIdempotencyKeys.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addIdempotencyKey(ctx, USER_TABLE);
+    addIdempotencyKey(ctx, ORGANIZATION_TABLE);
+    addIdempotencyKey(ctx, WORKSPACE_TABLE);
+    addIdempotencyKey(ctx, CONNECTION_TABLE);
+    addActorIdempotencyKey(ctx, "actor_definition");
+    addActorIdempotencyKey(ctx, "actor");
+  }
+
+  private static void addIdempotencyKey(final @NotNull DSLContext ctx, final @NotNull String table) {
+    final String columnName = "idempotency_key";
+    final String indexName = String.format("%s_idempotency_key", table);
+    final Field<UUID> idempotencyKey = DSL.field(columnName, SQLDataType.UUID.nullable(true));
+    ctx.alterTable(table).addColumnIfNotExists(idempotencyKey).execute();
+    ctx.createUniqueIndex(indexName).on(table, columnName).execute();
+  }
+
+  private static void addActorIdempotencyKey(final @NotNull DSLContext ctx, final @NotNull String table) {
+    final String columnName = "idempotency_key";
+    final String indexName = String.format("%s_actor_type_idempotency_key", table);
+    final Field<UUID> idempotencyKey = DSL.field(columnName, SQLDataType.UUID.nullable(true));
+    ctx.alterTable(table).addColumnIfNotExists(idempotencyKey).execute();
+    ctx.createUniqueIndex(indexName).on(table, columnName, "actor_type").execute();
+  }
+
+}

--- a/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
@@ -21,6 +21,7 @@ create table "public"."actor" (
   "created_at" timestamp(6) with time zone not null default current_timestamp,
   "updated_at" timestamp(6) with time zone not null default current_timestamp,
   "default_version_id" uuid not null,
+  "idempotency_key" uuid,
   constraint "actor_pkey"
     primary key ("id")
 );
@@ -58,6 +59,7 @@ create table "public"."actor_definition" (
   "custom" boolean not null default false,
   "max_seconds_between_messages" int,
   "default_version_id" uuid,
+  "idempotency_key" uuid,
   constraint "actor_definition_pkey"
     primary key ("id")
 );
@@ -100,7 +102,7 @@ create table "public"."actor_definition_version" (
   "allowed_hosts" jsonb,
   "suggested_streams" jsonb,
   "release_stage" "public"."release_stage",
-  "support_state" "public"."support_state" not null default cast('supported' as support_state),
+  "support_state" support_state not null default cast('supported' as support_state),
   "support_level" "public"."support_level" not null,
   constraint "actor_definition_version_pkey"
     primary key ("id"),
@@ -111,7 +113,7 @@ create table "public"."actor_definition_workspace_grant" (
   "actor_definition_id" uuid not null,
   "workspace_id" uuid,
   "scope_id" uuid,
-  "scope_type" "public"."scope_type" not null default cast('workspace' as scope_type),
+  "scope_type" scope_type not null default cast('workspace' as scope_type),
   constraint "actor_definition_workspace_gr_actor_definition_id_scope_id__key"
     unique ("actor_definition_id", "scope_id", "scope_type")
 );
@@ -158,10 +160,11 @@ create table "public"."connection" (
   "source_catalog_id" uuid,
   "schedule_type" "public"."schedule_type",
   "schedule_data" jsonb,
-  "geography" "public"."geography_type" not null default cast('AUTO' as geography_type),
+  "geography" geography_type not null default cast('AUTO' as geography_type),
   "non_breaking_change_preference" varchar(7) not null default cast('ignore' as varchar),
   "breaking_change" boolean not null default false,
   "field_selection_data" jsonb,
+  "idempotency_key" uuid,
   constraint "connection_pkey"
     primary key ("id")
 );
@@ -231,6 +234,7 @@ create table "public"."organization" (
   "pba" boolean not null default false,
   "org_level_billing" boolean not null default false,
   "tombstone" boolean not null default false,
+  "idempotency_key" uuid,
   constraint "organization_pkey"
     primary key ("id")
 );
@@ -264,7 +268,7 @@ create table "public"."schema_management" (
   "connection_id" uuid not null,
   "created_at" timestamp(6) with time zone not null default current_timestamp,
   "updated_at" timestamp(6) with time zone not null default current_timestamp,
-  "auto_propagation_status" "public"."auto_propagation_status" not null default cast('ignore' as auto_propagation_status),
+  "auto_propagation_status" auto_propagation_status not null default cast('ignore' as auto_propagation_status),
   constraint "schema_management_pkey"
     primary key ("id")
 );
@@ -297,7 +301,7 @@ create table "public"."scoped_configuration" (
 create table "public"."secret_persistence_config" (
   "id" uuid not null,
   "scope_id" uuid,
-  "scope_type" "public"."secret_persistence_scope_type" not null default cast('organization' as secret_persistence_scope_type),
+  "scope_type" secret_persistence_scope_type not null default cast('organization' as secret_persistence_scope_type),
   "secret_persistence_config_coordinate" varchar(256),
   "secret_persistence_type" "public"."secret_persistence_type" not null,
   "created_at" timestamp(6) with time zone not null default current_timestamp,
@@ -328,7 +332,7 @@ create table "public"."state" (
   "updated_at" timestamp(6) with time zone not null default current_timestamp,
   "stream_name" text,
   "namespace" text,
-  "type" "public"."state_type" not null default cast('LEGACY' as state_type),
+  "type" state_type not null default cast('LEGACY' as state_type),
   constraint "state_pkey"
     primary key ("id", "connection_id"),
   constraint "state__connection_id__stream_name__namespace__uq"
@@ -357,6 +361,7 @@ create table "public"."user" (
   "created_at" timestamp(6) with time zone not null default current_timestamp,
   "updated_at" timestamp(6) with time zone not null default current_timestamp,
   "auth_provider" "public"."auth_provider" not null,
+  "idempotency_key" uuid,
   constraint "user_pkey"
     primary key ("id"),
   constraint "auth_user_id_auth_provider_key"
@@ -426,6 +431,7 @@ create table "public"."workspace" (
   "webhook_operation_configs" jsonb,
   "notification_settings" jsonb,
   "organization_id" uuid,
+  "idempotency_key" uuid,
   constraint "workspace_pkey"
     primary key ("id")
 );
@@ -570,17 +576,21 @@ alter table "public"."workspace_service_account"
     references "public"."workspace" ("id");
 comment on column "public"."actor_definition"."max_seconds_between_messages" is 'Define the number of seconds allowed between 2 messages emitted by the connector before timing out';
 create index "actor_actor_definition_id_idx" on "public"."actor"("actor_definition_id" asc);
+create unique index "actor_idempotency_key_idx" on "public"."actor"("idempotency_key" asc);
 create index "actor_workspace_id_idx" on "public"."actor"("workspace_id" asc);
 create index "actor_catalog_catalog_hash_id_idx" on "public"."actor_catalog"("catalog_hash" asc);
 create index "actor_catalog_fetch_event_actor_catalog_id_idx" on "public"."actor_catalog_fetch_event"("actor_catalog_id" asc);
 create index "actor_catalog_fetch_event_actor_id_idx" on "public"."actor_catalog_fetch_event"("actor_id" asc);
+create unique index "actor_definition_idempotency_key_idx" on "public"."actor_definition"("idempotency_key" asc);
 create index "actor_oauth_parameter_workspace_definition_idx" on "public"."actor_oauth_parameter"("workspace_id" asc, "actor_definition_id" asc);
 create index "airbyte_configs_migrations_s_idx" on "public"."airbyte_configs_migrations"("success" asc);
 create index "connection_destination_id_idx" on "public"."connection"("destination_id" asc);
+create unique index "connection_idempotency_key_idx" on "public"."connection"("idempotency_key" asc);
 create index "connection_source_id_idx" on "public"."connection"("source_id" asc);
 create index "connection_status_idx" on "public"."connection"("status" asc);
 create index "connection_operation_connection_id_idx" on "public"."connection_operation"("connection_id" asc);
 create index "connector_builder_project_workspace_idx" on "public"."connector_builder_project"("workspace_id" asc);
+create unique index "organization_idempotency_key_idx" on "public"."organization"("idempotency_key" asc);
 create index "organization_email_domain_email_domain_idx" on "public"."organization_email_domain"("email_domain" asc);
 create index "organization_email_domain_organization_id_idx" on "public"."organization_email_domain"("organization_id" asc);
 create index "permission_organization_id_idx" on "public"."permission"("organization_id" asc);
@@ -592,9 +602,11 @@ create index "sso_config_organization_id_idx" on "public"."sso_config"("organiza
 create index "connection_id_stream_name_namespace_idx" on "public"."stream_reset"("connection_id" asc, "stream_name" asc, "stream_namespace" asc);
 create index "user_auth_provider_auth_user_id_idx" on "public"."user"("auth_provider" asc, "auth_user_id" asc);
 create index "user_email_idx" on "public"."user"("email" asc);
+create unique index "user_idempotency_key_idx" on "public"."user"("idempotency_key" asc);
 create index "user_invitation_invite_code_idx" on "public"."user_invitation"("invite_code" asc);
 create index "user_invitation_invited_email_idx" on "public"."user_invitation"("invited_email" asc);
 create index "user_invitation_organization_id_idx" on "public"."user_invitation"("organization_id" asc);
 create index "user_invitation_workspace_id_idx" on "public"."user_invitation"("workspace_id" asc);
 create index "workload_status_idx" on "public"."workload"("status" asc);
 create index "workload_label_workload_id_idx" on "public"."workload_label"("workload_id" asc);
+create unique index "workspace_idempotency_key_idx" on "public"."workspace"("idempotency_key" asc);


### PR DESCRIPTION
## What

Based on [[API] Idempotent Resource Creation](https://github.com/airbytehq/airbyte/discussions/33092) Discussion.

This change adds an `idempotencyKey` to the API and database tables. This enables an idempotent way to create resources; preventing duplicate creation of the same resource for retries and concurrent create requests.

## Why

And Idempotency key of some kind is necessary in order to prevent duplicates from being created in concurrent or retried requests.

For example, I often run into this scenario; especially if the Airbyte Server is under load (when it starts returning 504/502 errors):

 - Try to create a source/connection/destination/etc...
 - Get a 504/502 response back; indicating a timeout waiting for a server response.
 - Retry after some time
 - Initial request succeeds and creates a source/connection/destination/etc.
 - Retried request also succeeds and creates a source/connection/destination/etc.... with the same name

The more retries, the more duplicates.

Since no resource has any unique constraint besides its UUID (which is generated on creation) -- the server will gladly accept multiple create requests for an identical resource.

## How

1. Add a nullable uuid column called `idempotency_key` to the database tables of `organizations`, `users`, `workspaces`, `connections`, `actors`, and `actor_definitions`.
2. Add a unique index to prevent duplicate `idempotency_key` rows and fast lookup by `idempotency_key`.
3. Modify the API to accept an `idempotencyKey` value on create for these resources.
4. Create requests look up the value in the DB if it was provided, and will return the existing value instead of accepting the write.

## Recommended reading order

### Database Migrations

1. airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_50_33_016__AddIdempotencyKeys.java
2. airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
3. airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderTest.java

### API Changes

1. airbyte-api/src/main/openapi/config.yaml
2. airbyte-api/src/main/openapi/api.yaml

### API Server Mappings

1. airbyte-api-server/src/main/kotlin/io/airbyte/api/server/mappers/ConnectionCreateMapper.kt
2. airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/DestinationService.kt
3. airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/SourceService.kt
4. airbyte-api-server/src/main/kotlin/io/airbyte/api/server/services/WorkspaceService.kt

### Server Handlers


1. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/ConnectionsHandler.java
2. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/DestinationDefinitionsHandler.java
3. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/DestinationHandler.java
4. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/OrganizationsHandler.java
5. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SourceDefinitionsHandler.java
6. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SourceHandler.java
7. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/UserHandler.java
8. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
9. airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WorkspacesHandler.java
10. airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/DestinationDefinitionsHandlerTest.java
11. airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SourceDefinitionsHandlerTest.java
12. airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandlerTest.java

### Config Model Updates
1. airbyte-config/config-models/src/main/resources/types/DestinationConnection.yaml
2. airbyte-config/config-models/src/main/resources/types/IdempotencyKey.yaml
3. airbyte-config/config-models/src/main/resources/types/Organization.yaml
4. airbyte-config/config-models/src/main/resources/types/SourceConnection.yaml
5. airbyte-config/config-models/src/main/resources/types/StandardDestinationDefinition.yaml
6. airbyte-config/config-models/src/main/resources/types/StandardSourceDefinition.yaml
7. airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
8. airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
9. airbyte-config/config-models/src/main/resources/types/User.yaml

### Persistence Changes

1. airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/OrganizationPersistence.java
2. airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/UserPersistence.java
3. airbyte-data/src/main/java/io/airbyte/data/services/ConnectionService.java
4. airbyte-data/src/main/java/io/airbyte/data/services/DestinationService.java
5. airbyte-data/src/main/java/io/airbyte/data/services/SourceService.java
6. airbyte-data/src/main/java/io/airbyte/data/services/WorkspaceService.java
7. airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/ConnectionServiceJooqImpl.java
8. airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/DestinationServiceJooqImpl.java
9. airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/OrganizationServiceJooqImpl.java
10. airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/SourceServiceJooqImpl.java
11. airbyte-data/src/main/java/io/airbyte/data/services/impls/jooq/WorkspaceServiceJooqImpl.java

## Can this PR be safely reverted / rolled back?

- [ ] YES 💚
- [x] NO ❌

Contains API changes and DB migrations.

## 🚨 User Impact 🚨

This shouldn't be a breaking change, as the new idempotencyKey is an optional parameter; and behavior should
not be different than it currently is if it is not given in the API Calls.

