### PR TITLE
Update minio.yaml

### DIFF
--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -106,4 +106,15 @@ spec:
           value: {{ .Values.minio.auth.rootPassword }}
         - name: MINIO_ENDPOINT
           value: {{ .Values.minio.endpoint }}
+  nodeSelector:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.minio.affinity }}
+  affinity:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.minio.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
Added nodeselector, affinity and tolerations to "airbyte-minio-create-bucket" pod.

## What
"airbyte-minio-create-bucket" pod is not created, if k8s environment has no node with necessary tolerations.

## How
Used values from `minio` section to define nodeselector, affinity and toleration.

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
No breaking changes.
