### PR TITLE
fix(airbyte-api): regexp for JobsController orderBy

### DIFF
--- a/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/controllers/JobsController.kt
+++ b/airbyte-api-server/src/main/kotlin/io/airbyte/api/server/controllers/JobsController.kt
@@ -273,7 +273,7 @@ open class JobsController(
     var field: OrderByFieldEnum = OrderByFieldEnum.CREATEDAT
     var method: OrderByMethodEnum = OrderByMethodEnum.ASC
     if (orderBy != null) {
-      val pattern: java.util.regex.Pattern = java.util.regex.Pattern.compile("([a-zA-Z0-9]+)|(ASC|DESC)")
+      val pattern: java.util.regex.Pattern = java.util.regex.Pattern.compile("([a-zA-Z0-9]+)\\|(ASC|DESC)")
       val matcher: java.util.regex.Matcher = pattern.matcher(orderBy)
       if (!matcher.find()) {
         throw BadRequestProblem("Invalid order by clause provided: $orderBy")


### PR DESCRIPTION
## What
The regexp for the `orderBy` parameter is incorrect since it is using a bare pipe character which implies an alternate expression. However, what is expected is matching a literal pipe '|' character.

[Original Regexp](https://regex101.com/r/Nwk3uP/1)

```
([a-zA-Z0-9]+)|(ASC|DESC)
```

The expectation is that this will match `createdAt|ASC` and create the following matching groups:

1. `createdAt`
2. `ASC`

However, what this regexp actually means is:

```
# ---- right-hand-side regexp ---
( # start capture group 1
    [a-zA-Z0-9]+ # match alphanumeric string of one or more characters
)
# ---- right-hand-side regexp ---
| # match either right-hand-side OR left-hand-side regexp
# ---- left-hand-side regexp ---
( # start capture group 1
    ASC|DESC # match the literal string `ASC` OR `DESC`
)
# ---- left-hand-side regexp ---
```

Also note: the right-hand-side regexp will match anything the left-hand-side regexp could match, so that branch will never be taken.

## How

This change adds a '\' escape before the '|' so that the regexp matches the literal character.

[Fixed Regexp](https://regex101.com/r/zEKYNd/1)

```
([a-zA-Z0-9]+)\|(ASC|DESC)
```

This will correctly match the string `createdAt|ASC` as:

1. createdAt
2. ASC

## Recommended reading order
1. `airbyte-api-server/src/main/kotlin/io/airbyte/api/server/controllers/JobsController.kt`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [X] YES 💚

## 🚨 User Impact 🚨
No
