### PR TITLE
Add LOG4J_CONFIGURATION_FILE env var to server

### DIFF
--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-airbyte-secrets
               key: DATABASE_USER
+        - name: LOG4J_CONFIGURATION_FILE
+          valueFrom:
+              name: {{ .Release.Name }}-airbyte-env
+              key: LOG4J_CONFIGURATION_FILE
         - name: MICROMETER_METRICS_ENABLED
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## What
In https://github.com/airbytehq/airbyte/issues/34348 worker was fixed, however server is experiencing same issue as worker did. 


## How
LOG4J_CONFIGURATION_FILE should be set for both worker and server pods. 

## Recommended reading order
1. `x.java`
2. `y.java`

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [ ] YES 💚
- [X] NO ❌

## 🚨 User Impact 🚨
Might need to remove some custom changes in order to use global.log4jConfig 