### PR TITLE
Add loadBalancerIP to service spec in APIs charts

### DIFF
--- a/charts/airbyte-api-server/templates/service.yaml
+++ b/charts/airbyte-api-server/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/airbyte-api-server/values.yaml
+++ b/charts/airbyte-api-server/values.yaml
@@ -1,4 +1,3 @@
-
 global:
   serviceAccountName: placeholderServiceAccount
   deploymentMode: oss
@@ -136,6 +135,7 @@ resources:
 ##  service.port The service port to expose the API server on
 service:
   type: ClusterIP
+  loadBalancerIP: ""
   port: 8006
   annotations: {}
 
@@ -255,12 +255,10 @@ secrets: {}
 #   CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: 0.35.15.001
 env_vars: {}
 
-
 ## extraSelectorLabels [object] - use to specify own additional selector labels for deployment
 extraSelectorLabels: {}
 ## extraLabels [object] - use to specify own additional labels for deployment
 extraLabels: {}
-
 
 ## deploymentStrategyType [string] - deployment strategy type for airbyte-server deployment.
 ## Defaults to Recreate since the pod is using pvc

--- a/charts/airbyte-server/templates/service.yaml
+++ b/charts/airbyte-server/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http

--- a/charts/airbyte-server/values.yaml
+++ b/charts/airbyte-server/values.yaml
@@ -1,4 +1,3 @@
-
 global:
   serviceAccountName: placeholderServiceAccount
   edition: community
@@ -98,6 +97,7 @@ resources:
 ##  service.port The service port to expose the API server on
 service:
   type: ClusterIP
+  loadBalancerIP: ""
   port: 8001
   annotations: {}
 
@@ -193,12 +193,10 @@ secrets: {}
 #   CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: 0.35.15.001
 env_vars: {}
 
-
 ## extraSelectorLabels [object] - use to specify own additional selector labels for deployment
 extraSelectorLabels: {}
 ## extraLabels [object] - use to specify own additional labels for deployment
 extraLabels: {}
-
 
 ## deploymentStrategyType [string] - deployment strategy type for airbyte-server deployment.
 ## Defaults to Recreate since the pod is using pvc


### PR DESCRIPTION
## What

Hi !

I'd like to add `loadBalancerIP` to service spec to allow use cases such as Internal Load Balancers on Google Kubernetes Engine with static internal IP reserved in advance.  
It helps with:
- Increasing security by not exposing the service with an external IP.
- Allowing more advanced automation in provisioning infrastructure.

See [this](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer#load_balancer_types), [this](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#enabling_internal_load_balancer_subsetting_in_a_new_cluster) and [this](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters).

## How

Tested on GKE v1.27.8-gke.1067004 STABLE Release Channel.

```yaml
service:
  type: LoadBalancer
  loadBalancerIP: 10.42.0.30
  annotations:
    networking.gke.io/load-balancer-type: "Internal"
```

## Can this PR be safely reverted / rolled back?

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨

Nothing breaking for anyone, only adds more use cases.