### PR TITLE
Use merge policy instead of fallbacks for KubeResourceConfig

### DIFF
--- a/airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/KubeResourceConfig.java
+++ b/airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/KubeResourceConfig.java
@@ -6,20 +6,19 @@ package io.airbyte.commons.workers.config;
 
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
-
 import java.util.Objects;
 import java.util.Optional;
 
 /**
  * Encapsulates the configuration that is specific to Kubernetes. This is meant for the
- * WorkerConfigsProvider to be reading configs, not for direct use as merge logic isn't
- * implemented here.
- * Important: we cannot distinguish between empty and non-existent environment variables
- * in this context, so we treat empty and non-existing strings as the same for our update
- * logic. We use the <EMPTY> literal to represent an empty string.
+ * WorkerConfigsProvider to be reading configs, not for direct use as merge logic isn't implemented
+ * here. Important: we cannot distinguish between empty and non-existent environment variables in
+ * this context, so we treat empty and non-existing strings as the same for our update logic. We use
+ * the "&lt;EMPTY&gt;" literal to represent an empty string.
  */
 @EachProperty("airbyte.worker.kube-job-configs")
 public final class KubeResourceConfig implements Cloneable {
+
   public static final String EMPTY_VALUE = "<EMPTY>";
 
   private final String name;
@@ -124,4 +123,5 @@ public final class KubeResourceConfig implements Cloneable {
     // Let's no return null values as it can be ambiguous
     return (Objects.equals(value, EMPTY_VALUE)) ? "" : Optional.ofNullable(value).orElse("");
   }
+
 }

--- a/airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/KubeResourceConfig.java
+++ b/airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/KubeResourceConfig.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  * the "&lt;EMPTY&gt;" literal to represent an empty string.
  */
 @EachProperty("airbyte.worker.kube-job-configs")
-public final class KubeResourceConfig implements Cloneable {
+public final class KubeResourceConfig {
 
   public static final String EMPTY_VALUE = "<EMPTY>";
 
@@ -34,25 +34,18 @@ public final class KubeResourceConfig implements Cloneable {
     this.name = name;
   }
 
-  public KubeResourceConfig clone() {
-    try {
-      return (KubeResourceConfig) super.clone();
-    } catch (final CloneNotSupportedException e) {
-      // Unlikely, but in the worst case, we will get this error when running tests.
-      throw new RuntimeException(e);
-    }
-  }
+  public KubeResourceConfig merge(KubeResourceConfig other) {
+    var merged = new KubeResourceConfig(name);
 
-  public KubeResourceConfig update(KubeResourceConfig other) {
-    annotations = useOtherIfEmpty(other.annotations, annotations);
-    labels = useOtherIfEmpty(other.labels, labels);
-    nodeSelectors = useOtherIfEmpty(other.nodeSelectors, nodeSelectors);
-    cpuLimit = useOtherIfEmpty(other.cpuLimit, cpuLimit);
-    cpuRequest = useOtherIfEmpty(other.cpuRequest, cpuRequest);
-    memoryLimit = useOtherIfEmpty(other.memoryLimit, memoryLimit);
-    memoryRequest = useOtherIfEmpty(other.memoryRequest, memoryRequest);
+    merged.setAnnotations(useOtherIfEmpty(annotations, other.annotations));
+    merged.setLabels(useOtherIfEmpty(labels, other.labels));
+    merged.setNodeSelectors(useOtherIfEmpty(nodeSelectors, other.nodeSelectors));
+    merged.setCpuLimit(useOtherIfEmpty(cpuLimit, other.cpuLimit));
+    merged.setCpuRequest(useOtherIfEmpty(cpuRequest, other.cpuRequest));
+    merged.setMemoryLimit(useOtherIfEmpty(memoryLimit, other.memoryLimit));
+    merged.setMemoryRequest(useOtherIfEmpty(memoryRequest, other.memoryRequest));
 
-    return this;
+    return merged;
   }
 
   public String getName() {

--- a/airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/WorkerConfigsProvider.java
+++ b/airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/WorkerConfigsProvider.java
@@ -282,7 +282,7 @@ public class WorkerConfigsProvider implements ResourceRequirementsProvider {
     if (defaultConfig.isEmpty()) {
       return variantConfig;
     }
-    return variantConfig.map(kubeResourceConfig -> defaultConfig.get().clone().update(kubeResourceConfig)).or(() -> defaultConfig);
+    return variantConfig.map(kubeResourceConfig -> kubeResourceConfig.merge(defaultConfig.get())).or(() -> defaultConfig);
   }
 
   private static Optional<KubeResourceConfig> getKubeResourceConfigByType(
@@ -301,7 +301,7 @@ public class WorkerConfigsProvider implements ResourceRequirementsProvider {
     if (defaultConfig.isEmpty()) {
       return typeConfig;
     }
-    return typeConfig.map(kubeResourceConfig -> defaultConfig.get().clone().update(kubeResourceConfig)).or(() -> defaultConfig);
+    return typeConfig.map(kubeResourceConfig -> kubeResourceConfig.merge(defaultConfig.get())).or(() -> defaultConfig);
   }
 
   private static Optional<KubeResourceConfig> getKubeResourceConfigBySubType(final Map<ResourceSubType, KubeResourceConfig> configBySubType,
@@ -319,7 +319,7 @@ public class WorkerConfigsProvider implements ResourceRequirementsProvider {
     if (defaultConfig.isEmpty()) {
       return subTypeConfig;
     }
-    return subTypeConfig.map(kubeResourceConfig -> defaultConfig.get().clone().update(kubeResourceConfig)).or(() -> defaultConfig);
+    return subTypeConfig.map(kubeResourceConfig -> kubeResourceConfig.merge(defaultConfig.get())).or(() -> defaultConfig);
   }
 
   private void validateIsolatedPoolConfigInitialization(final boolean useCustomNodeSelector, final Map<String, String> isolatedNodeSelectors) {

--- a/airbyte-commons-with-dependencies/src/test/java/io/airbyte/commons/workers/config/WorkerConfigProviderMicronautTest.java
+++ b/airbyte-commons-with-dependencies/src/test/java/io/airbyte/commons/workers/config/WorkerConfigProviderMicronautTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.commons.workers.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.airbyte.commons.workers.config.WorkerConfigsProvider.ResourceType;
 import io.airbyte.config.ResourceRequirements;
@@ -59,7 +58,7 @@ class WorkerConfigProviderMicronautTest {
   @Test
   void testKubeConfigIsReadingAllTheFields() {
     assertEquals("check", checkKubeResourceConfig.getName());
-    assertEquals("check annotations", checkKubeResourceConfig.getAnnotations());
+    assertEquals("check_annotation_key=check_annotation_value", checkKubeResourceConfig.getAnnotations());
     assertEquals("check labels", checkKubeResourceConfig.getLabels());
     assertEquals("check node-selectors", checkKubeResourceConfig.getNodeSelectors());
     assertEquals("check cpu limit", checkKubeResourceConfig.getCpuLimit());
@@ -71,11 +70,11 @@ class WorkerConfigProviderMicronautTest {
   @Test
   void testDefaultFieldBehavior() {
     assertEquals("spec", specKubeResourceConfig.getName());
-    assertEquals("spec annotations", specKubeResourceConfig.getAnnotations());
+    assertEquals("", specKubeResourceConfig.getAnnotations());
     assertEquals("spec labels", specKubeResourceConfig.getLabels());
     assertEquals("spec node selectors", specKubeResourceConfig.getNodeSelectors());
-    assertNull(specKubeResourceConfig.getCpuLimit());
-    assertNull(specKubeResourceConfig.getCpuRequest());
+    assertEquals("", specKubeResourceConfig.getCpuLimit());
+    assertEquals("", specKubeResourceConfig.getCpuRequest());
     assertEquals("spec memory limit", specKubeResourceConfig.getMemoryLimit());
     assertEquals("", specKubeResourceConfig.getMemoryRequest());
   }

--- a/airbyte-commons-with-dependencies/src/test/java/io/airbyte/commons/workers/config/WorkerConfigProviderMicronautTest.java
+++ b/airbyte-commons-with-dependencies/src/test/java/io/airbyte/commons/workers/config/WorkerConfigProviderMicronautTest.java
@@ -85,9 +85,9 @@ class WorkerConfigProviderMicronautTest {
     final WorkerConfigs specKubeConfig = workerConfigsProvider.getConfig(ResourceType.SPEC);
 
     assertEquals("default cpu limit", specKubeConfig.getResourceRequirements().getCpuLimit());
-    assertEquals("", specKubeConfig.getResourceRequirements().getCpuRequest());
+    assertEquals("default cpu request", specKubeConfig.getResourceRequirements().getCpuRequest());
     assertEquals("spec memory limit", specKubeConfig.getResourceRequirements().getMemoryLimit());
-    assertEquals("", specKubeConfig.getResourceRequirements().getMemoryRequest());
+    assertEquals("default memory request", specKubeConfig.getResourceRequirements().getMemoryRequest());
   }
 
   @Test
@@ -120,18 +120,22 @@ class WorkerConfigProviderMicronautTest {
         testVariant);
     final ResourceRequirements testSourceDatabase = workerConfigsProvider.getResourceRequirements(ResourceRequirementsType.SOURCE, Optional.of(
         "database"), testVariant);
+    final WorkerConfigs checkConfig = workerConfigsProvider.getConfig(ResourceType.CHECK);
+    final WorkerConfigs specConfig = workerConfigsProvider.getConfig(ResourceType.SPEC);
 
     // Testing the variant override lookup
     assertEquals("5", testSourceApi.getCpuLimit());
     assertEquals("10", testSourceDatabase.getCpuLimit());
     assertEquals("default cpu limit", sourceApi.getCpuLimit());
     assertEquals("default cpu limit", sourceDatabase.getCpuLimit());
+    assertEquals(Map.of("check_annotation_key", "check_annotation_value"), checkConfig.getWorkerKubeAnnotations());
 
     // Verifying the default inheritance
     assertEquals("0.5", sourceApi.getCpuRequest());
     assertEquals("1", sourceDatabase.getCpuRequest());
     assertEquals("", testSourceApi.getCpuRequest());
     assertEquals("", testSourceDatabase.getCpuRequest());
+    assertEquals(Map.of("default_annotation_key", "default_annotation_value"), specConfig.getWorkerKubeAnnotations());
   }
 
   @Test

--- a/airbyte-commons-with-dependencies/src/test/resources/application-config-test.yaml
+++ b/airbyte-commons-with-dependencies/src/test/resources/application-config-test.yaml
@@ -5,11 +5,12 @@ airbyte:
   worker:
     kube-job-configs:
       default:
+        annotations: default_annotation_key=default_annotation_value
         cpu-limit: default cpu limit
-        cpu-request: ${JOB_MAIN_CONTAINER_CPU_REQUEST:}
-        memory-request: ${JOB_MAIN_CONTAINER_MEMORY_REQUEST:}
+        cpu-request: default cpu request
+        memory-request: default memory request
       check:
-        annotations: ${CHECK_JOB_KUBE_ANNOTATIONS:check annotations}
+        annotations: ${CHECK_JOB_KUBE_ANNOTATIONS:check_annotation_key=check_annotation_value}
         labels: ${CHECK_JOB_KUBE_LABELS:check labels}
         node-selectors: ${CHECK_JOB_KUBE_NODE_SELECTORS:check node-selectors}
         cpu-limit: ${CHECK_JOB_MAIN_CONTAINER_CPU_LIMIT:check cpu limit}
@@ -17,7 +18,7 @@ airbyte:
         memory-limit: ${CHECK_JOB_MAIN_CONTAINER_MEMORY_LIMIT:check mem limit}
         memory-request: ${CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST:check mem request}
       spec:
-        annotations: ${SPEC_JOB_KUBE_ANNOTATIONS:spec annotations}
+        annotations: ${SPEC_JOB_KUBE_ANNOTATIONS:}
         labels: ${SPEC_JOB_KUBE_LABELS:spec labels}
         node-selectors: ${SPEC_JOB_KUBE_NODE_SELECTORS:spec node selectors}
         memory-limit: spec memory limit
@@ -38,6 +39,7 @@ airbyte:
         cpu-request: 42
       micronauttest-source:
         cpu-limit: 5
+        cpu-request: <EMPTY> # Disable inheritance, force empty value
       micronauttest-source-database:
         cpu-limit: 10
       mappingtest-source-stderr:

--- a/airbyte-container-orchestrator/src/main/resources/application.yml
+++ b/airbyte-container-orchestrator/src/main/resources/application.yml
@@ -105,6 +105,7 @@ airbyte:
     kube-job-configs:
       default:
         annotations: ${JOB_KUBE_ANNOTATIONS:}
+        labels: ${JOB_KUBE_LABELS:}
         node-selectors: ${JOB_KUBE_NODE_SELECTORS:}
         cpu-limit: ${JOB_MAIN_CONTAINER_CPU_LIMIT:}
         cpu-request: ${JOB_MAIN_CONTAINER_CPU_REQUEST:}


### PR DESCRIPTION
## What
Fix for https://github.com/airbytehq/airbyte/issues/33068

But the problem is more complex.
Logic in `io.airbyte.commons.workers.config.WorkerConfigsProvider`  is opaque.
The main strategy of resolving `KubeResourceConfig` is to fallback to the default for the whole config: if we cannot find the exact key, we will choose the closest default section.
However, there are some exceptions: annotations and `ResourceRequirements` (cpu/memory limits/requests). If any of these are empty, we will attempt to update them using the default config.

In addition, the current fallback logic does not work well for Helm OSS installations.
We parameterize config values via environment variables.
And there is no way to remove a section from the `application.yml` without using a custom image.
So one must setup all variables `JOB_KUBE_LABELS`, `CHECK_JOB_KUBE_LABELS`, `DISCOVER_JOB_KUBE_LABELS`, `REPLICATION_JOB_KUBE_LABELS`, `SPEC_JOB_KUBE_LABELS` in case they want to use common k8s labels (for example, `azure.workload.identity/use`).

The last issue I have is that I am not sure how to set a `null` value for a field in a `KubeResourceConfig` using environment variables.

## How
I suggest to introduce two breaking changes:
1. Use a merge strategy to resolve `KubeResourceConfig`. It's more intuitive and powerful.
2. Use the literal `<EMPTY>` to differentiate between empty and null fields.

The merge strategy will use the same order as previously: variant, type, subtype.
But it will try to merge configs based on `COALESCE(value, default_value)` for every field in `KubeResourceConfig` for every key part.
With this we don't need custom logic for annotations and `ResourceRequirements`.

`<EMPTY>` literal is needed to override defaults with empty values.

## Recommended reading order
1. `airbyte-commons-with-dependencies/src/test/resources/application-config-test.yaml`
2. `airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/WorkerConfigsProvider.java`
3. `airbyte-commons-with-dependencies/src/main/java/io/airbyte/commons/workers/config/KubeResourceConfig.java`
4. all other files

## Can this PR be safely reverted / rolled back?
*If you know that your PR is backwards-compatible and can be simply reverted or rolled back, check the YES box.*

*Otherwise if your PR has a breaking change, like a database migration for example, check the NO box.*

*If unsure, leave it blank.*
- [x] YES 💚
- [ ] NO ❌

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
