### PR TITLE
Update the Helm Chart to set an AIRBYTE_API_HOST in OSS and Enterprise

### DIFF
--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -67,6 +67,11 @@ spec:
           value: "true"
         {{- end }}
         {{- if eq .Values.global.deploymentMode "oss"  }}
+        - name: AIRBYTE_API_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: AIRBYTE_API_HOST
         - name: AIRBYTE_VERSION
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -46,7 +46,7 @@ data:
   KEYCLOAK_INTERNAL_HOST: localhost # just a placeholder so that nginx template is valid - shouldn't be used when edition isn't "pro"
 {{- end }}
   CONNECTOR_BUILDER_API_HOST: {{ .Release.Name }}-airbyte-connector-builder-server-svc:{{ index .Values "connector-builder-server" "service" "port" }}
-  AIRBYTE_API_HOST: {{ .Release.Name }}-airbyte-api-server-svc:{{ index .Values "airbyte-api-server" "service" "port" }}
+  AIRBYTE_API_HOST: {{ printf "%s/api/public/v1" (index $airbyteYmlDict "webapp-url") | quote }}
 {{- if $.Values.global.jobs.kube.annotations }}
   JOB_KUBE_ANNOTATIONS: {{ $.Values.global.jobs.kube.annotations | include "airbyte.flattenMap" | quote }}
 {{- end }}

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -46,7 +46,11 @@ data:
   KEYCLOAK_INTERNAL_HOST: localhost # just a placeholder so that nginx template is valid - shouldn't be used when edition isn't "pro"
 {{- end }}
   CONNECTOR_BUILDER_API_HOST: {{ .Release.Name }}-airbyte-connector-builder-server-svc:{{ index .Values "connector-builder-server" "service" "port" }}
-  AIRBYTE_API_HOST: {{ printf "%s/api/public/v1" (index $airbyteYmlDict "webapp-url") | quote }}
+  {{- if or (eq .Values.global.edition "pro") (eq .Values.global.edition "enterprise") }}
+  AIRBYTE_API_HOST: {{ printf "%s" (index $airbyteYmlDict "webapp-url") | quote }}
+  {{- else }}
+  AIRBYTE_API_HOST: http://{{ .Release.Name }}-airbyte-server-svc:{{ .Values.server.service.port }}/api/public
+  {{- end }}
 {{- if $.Values.global.jobs.kube.annotations }}
   JOB_KUBE_ANNOTATIONS: {{ $.Values.global.jobs.kube.annotations | include "airbyte.flattenMap" | quote }}
 {{- end }}


### PR DESCRIPTION
Use the webapp-url when deploying as Enterprise and the internal service name in OSS.

## Can this PR be safely reverted / rolled back?
- [X] YES 💚
