### PR TITLE
Support for HTTP1.1 in nginx configuration

### DIFF
--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -39,6 +39,7 @@ server {
         proxy_read_timeout 1h;
         client_max_body_size 200M;
         proxy_pass http://api-server/api/;
+        proxy_http_version 1.1;
 
         # Unset X-Airbyte-Auth header so that it cannot be used by external requests for authentication
         proxy_set_header X-Airbyte-Auth "";
@@ -49,6 +50,7 @@ server {
         proxy_read_timeout 1h;
         client_max_body_size 200M;
         proxy_pass http://connector-builder-server/;
+        proxy_http_version 1.1;
     }
 
     location /auth/ {


### PR DESCRIPTION
## What
By default Airbyte webapp proxies HTTP request using HTTP1.0 protocol. This may lead to 426 Upgrade required responses. 
This PR upgrade nginx configuration to use HTTP1.1

## How
proxy_http_version is set to 1.1
Reference:
https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
