### PR TITLE
Add an optional endpoint to S3 configs

### DIFF
--- a/airbyte-commons-worker/src/main/kotlin/io/airbyte/workers/storage/StorageClient.kt
+++ b/airbyte-commons-worker/src/main/kotlin/io/airbyte/workers/storage/StorageClient.kt
@@ -322,6 +322,10 @@ internal fun S3StorageConfig.s3Client(): S3Client {
     }
   }
 
+  if (this@s3Client.endpoint != null) {
+    builder.endpointOverride(URI(this@s3Client.endpoint))
+  }
+
   return builder.build()
 }
 

--- a/airbyte-commons-worker/src/main/kotlin/io/airbyte/workers/sync/OrchestratorConstants.kt
+++ b/airbyte-commons-worker/src/main/kotlin/io/airbyte/workers/sync/OrchestratorConstants.kt
@@ -81,6 +81,7 @@ object OrchestratorConstants {
           EnvVar.AWS_ASSUME_ROLE_SECRET_ACCESS_KEY,
           EnvVar.AWS_DEFAULT_REGION,
           EnvVar.AWS_SECRET_ACCESS_KEY,
+          EnvVar.AWS_ENDPOINT,
           EnvVar.DD_AGENT_HOST,
           EnvVar.DD_DOGSTATSD_PORT,
           EnvVar.DOCKER_HOST,

--- a/airbyte-commons/src/main/resources/log4j2-s3.xml
+++ b/airbyte-commons/src/main/resources/log4j2-s3.xml
@@ -12,6 +12,7 @@
 
         <!-- Note that logging to S3 will leverage the DefaultAWSCredentialsProviderChain for auth. -->
         <Property name="s3-bucket">${sys:STORAGE_BUCKET_LOG:-${env:STORAGE_BUCKET_LOG:-}}</Property>
+        <Property name="s3-endpoint">${sys:AWS_ENDPOINT:-${env:AWS_ENDPOINT}}</Property>
         <Property name="s3-region">${sys:AWS_DEFAULT_REGION:-${env:AWS_DEFAULT_REGION:-}}</Property>
     </Properties>
 
@@ -115,7 +116,8 @@
                     <Log4j2Appender name="${ctx:cloud_job_log_path}"
                       verbose="false"
                       stagingBufferAge="1"
-                      s3Bucket="${s3-bucket}" s3Path="job-logging${ctx:cloud_job_log_path}" s3Region="${s3-region}">
+                      s3Bucket="${s3-bucket}" s3Path="job-logging${ctx:cloud_job_log_path}" s3Region="${s3-region}"
+                      s3ServiceEndpoint="${s3-endpoint}">
                         <PatternLayout pattern="${default-pattern}"/>
                     </Log4j2Appender>
                 </Route>
@@ -136,7 +138,8 @@
                     <Log4j2Appender name="${ctx:cloud_job_log_path}"
                                     verbose="false"
                                     stagingBufferAge="1"
-                                    s3Bucket="${s3-bucket}" s3Path="job-logging${ctx:cloud_job_log_path}" s3Region="${s3-region}">
+                                    s3Bucket="${s3-bucket}" s3Path="job-logging${ctx:cloud_job_log_path}" s3Region="${s3-region}"
+                                    s3ServiceEndpoint="${s3-endpoint}">
                         <PatternLayout pattern="${simple-pattern}"/>
                     </Log4j2Appender>
                 </Route>
@@ -175,7 +178,8 @@
                 <Route>
                     <Log4j2Appender name="app-logging/${ctx:cloud_workspace_app_root}/"
                       stagingBufferAge="1"
-                      s3Bucket="${s3-bucket}" s3Path="app-logging${ctx:cloud_workspace_app_root}" s3Region="${s3-region}">
+                      s3Bucket="${s3-bucket}" s3Path="app-logging${ctx:cloud_workspace_app_root}" s3Region="${s3-region}"
+                      s3ServiceEndpoint="${s3-endpoint}">
                         <PatternLayout pattern="${default-pattern}"/>
                     </Log4j2Appender>
                 </Route>

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/storage/CloudStorageConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/storage/CloudStorageConfigs.java
@@ -152,14 +152,20 @@ public class CloudStorageConfigs {
   public static class S3Config extends S3ApiWorkerStorageConfig {
 
     private final String region;
+    private final String endpoint;
 
-    public S3Config(final String bucketName, final String awsAccessKey, final String awsSecretAccessKey, final String region) {
+    public S3Config(final String bucketName, final String awsAccessKey, final String awsSecretAccessKey, final String region, final String endpoint) {
       super(bucketName, awsAccessKey, awsSecretAccessKey);
       this.region = region;
+      this.endpoint = endpoint;
     }
 
     public String getRegion() {
       return region;
+    }
+
+    public String getEndpoint() {
+      return endpoint;
     }
 
   }

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java
@@ -31,6 +31,9 @@ public class DefaultS3ClientFactory implements Supplier<S3Client> {
       builder.credentialsProvider(() -> AwsBasicCredentials.create(config.getAccessKey(), config.getSecretAccessKey()));
     }
     builder.region(Region.of(config.getRegion()));
+    if (config.getEndpoint() != null) {
+      builder.endpointOverride(URI(config.getEndpoint()));
+    }
     return builder.build();
   }
 

--- a/airbyte-config/config-models/src/main/kotlin/io/airbyte/config/storage/CloudStorageBeanFactory.kt
+++ b/airbyte-config/config-models/src/main/kotlin/io/airbyte/config/storage/CloudStorageBeanFactory.kt
@@ -43,7 +43,7 @@ class CloudStorageBeanFactory {
   fun s3StateStorageConfiguration(storageConfig: StorageConfig): CloudStorageConfigs {
     if (storageConfig is S3StorageConfig) {
       return CloudStorageConfigs.s3(
-        S3Config(storageConfig.buckets.state, storageConfig.accessKey, storageConfig.secretAccessKey, storageConfig.region),
+        S3Config(storageConfig.buckets.state, storageConfig.accessKey, storageConfig.secretAccessKey, storageConfig.region, storageConfig.endpoint),
       )
     }
 

--- a/airbyte-config/config-models/src/main/kotlin/io/airbyte/config/storage/StorageConfig.kt
+++ b/airbyte-config/config-models/src/main/kotlin/io/airbyte/config/storage/StorageConfig.kt
@@ -86,6 +86,7 @@ data class S3StorageConfig(
   @Value("\${$STORAGE_S3.access-key}") val accessKey: String?,
   @Value("\${$STORAGE_S3.secret-access-key}") val secretAccessKey: String?,
   @Value("\${$STORAGE_S3.region}") val region: String,
+  @Value("\${$STORAGE_S3.endpoint}") val endpoint: String?,
 ) : StorageConfig {
   override fun toEnvVarMap(): Map<String, String> =
     buildMap {
@@ -101,9 +102,12 @@ data class S3StorageConfig(
         put(EnvVar.AWS_SECRET_ACCESS_KEY, secretAccessKey)
       }
       put(EnvVar.AWS_DEFAULT_REGION, region)
+      endpoint?.let {
+        put(EnvVar.AWS_ENDPOINT, endpoint)
+      }
     }.mapKeys { it.key.name }
 
-  override fun toString(): String = "S3StorageConfig(accessKey=${accessKey.mask()}, secretAccessKey=${secretAccessKey.mask()}, region=$region)"
+  override fun toString(): String = "S3StorageConfig(accessKey=${accessKey.mask()}, secretAccessKey=${secretAccessKey.mask()}, region=$region, endpoint=$endpoint)"
 }
 
 /**

--- a/airbyte-config/config-models/src/test/kotlin/io/airbyte/config/storage/StorageConfigTest.kt
+++ b/airbyte-config/config-models/src/test/kotlin/io/airbyte/config/storage/StorageConfigTest.kt
@@ -138,6 +138,7 @@ class S3StorageConfigTest {
       assertEquals("access", this.accessKey)
       assertEquals("secret-access", secretAccessKey)
       assertEquals("us-moon-1", region)
+      assertEquals("endpoint", endpoint)
     }
   }
 
@@ -154,6 +155,7 @@ class S3StorageConfigTest {
           EnvVar.AWS_ACCESS_KEY_ID to "access",
           EnvVar.AWS_SECRET_ACCESS_KEY to "secret-access",
           EnvVar.AWS_DEFAULT_REGION to "us-moon-1",
+          EnvVar.AWS_ENDPOINT to "endpoint",
         ).mapKeys { it.key.name }
 
       assertEquals(expected, toEnvVarMap())

--- a/airbyte-config/config-models/src/test/resources/application-storage-s3.yml
+++ b/airbyte-config/config-models/src/test/resources/application-storage-s3.yml
@@ -11,3 +11,4 @@ airbyte:
         access-key: access
         secret-access-key: secret-access
         region: us-moon-1
+        endpoint: endpoint

--- a/airbyte-server/src/main/kotlin/io/airbyte/server/config/CloudStorageBeanFactory.kt
+++ b/airbyte-server/src/main/kotlin/io/airbyte/server/config/CloudStorageBeanFactory.kt
@@ -95,7 +95,7 @@ class CloudStorageBeanFactory {
   fun s3StateStorageConfiguration(storageConfig: StorageConfig): CloudStorageConfigs {
     if (storageConfig is S3StorageConfig) {
       return CloudStorageConfigs.s3(
-        S3Config(storageConfig.buckets.state, storageConfig.accessKey, storageConfig.secretAccessKey, storageConfig.region),
+        S3Config(storageConfig.buckets.state, storageConfig.accessKey, storageConfig.secretAccessKey, storageConfig.region, storageConfig.endpoint),
       )
     }
 

--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -331,6 +331,13 @@ spec:
               name: {{ .Release.Name }}-airbyte-env
               key: AWS_DEFAULT_REGION
         {{- end }}
+        {{- if ((((.Values.global).storage).s3).endpoint) }}
+        - name: AWS_ENDPOINT # todo: change to S3_ENDPOINT, changes need to be pushed to the applications.yaml files
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: AWS_ENDPOINT
+        {{- end }}
         - name: S3_PATH_STYLE_ACCESS
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -434,6 +434,13 @@ spec:
               name: {{ .Release.Name }}-airbyte-env
               key: AWS_DEFAULT_REGION
         {{- end }}
+        {{- if ((((.Values.global).storage).s3).endpoint) }}
+        - name: AWS_ENDPOINT # todo: change to S3_ENDPOINT, changes need to be pushed to the applications.yaml files
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: AWS_ENDPOINT
+        {{- end }}
         - name: S3_PATH_STYLE_ACCESS
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte-workload-launcher/templates/deployment.yaml
+++ b/charts/airbyte-workload-launcher/templates/deployment.yaml
@@ -528,6 +528,13 @@ spec:
               name: {{ .Release.Name }}-airbyte-env
               key: AWS_DEFAULT_REGION
         {{- end }}
+        {{- if ((((.Values.global).storage).s3).endpoint) }}
+        - name: AWS_ENDPOINT # todo: change to S3_ENDPOINT, changes need to be pushed to the applications.yaml files
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: AWS_ENDPOINT
+        {{- end }}
         - name: S3_PATH_STYLE_ACCESS
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -92,7 +92,8 @@ data:
   STORAGE_BUCKET_LOG: {{ ((((.Values.global).storage).bucket).log) | default "airbyte-storage" | quote }}
   STORAGE_BUCKET_STATE: {{ ((((.Values.global).storage).bucket).state) | default "airbyte-storage" | quote }}
   STORAGE_BUCKET_WORKLOAD_OUTPUT: {{ ((((.Values.global).storage).bucket).workloadOutput) | default "airbyte-storage" | quote }}
-  AWS_DEFAULT_REGION: {{ ((((.Values.global).storage).s3).region) | default ""  | quote }}
+  AWS_DEFAULT_REGION: {{ ((((.Values.global).storage).s3).region) | default "" | quote }}
+  AWS_ENDPOINT: {{ ((((.Values.global).storage).s3).endpoint) | default "" | quote }}
   MINIO_ENDPOINT: {{ include "airbyte.storage.minio.endpoint" . | quote }}
   S3_PATH_STYLE_ACCESS: {{ include "airbyte.s3PathStyleAccess" . | quote }}
   # Storage end


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->

I would like to be able to use Airbyte OSS with a S3-compatible storage for logs. The only missing piece is to be able to give a custom endpoint to S3 clients.

## How
<!--
* Describe how code changes achieve the solution.
-->

I add an optionnal argument, `endpoint` to the S3 storage

## Recommended reading order
1. `CloudStorageConfigs.java`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
