### PR TITLE
Expose `webapp.service.targetPort` as a Helm chart value

### DIFF
--- a/charts/airbyte-webapp/README.md
+++ b/charts/airbyte-webapp/README.md
@@ -64,6 +64,7 @@ Helm chart to deploy airbyte-webapp
 | secrets | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.port | int | `80` |  |
+| service.targetPort | string OR int | `"http"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 

--- a/charts/airbyte-webapp/templates/service.yaml
+++ b/charts/airbyte-webapp/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.port }}
-    targetPort: http
+    targetPort: {{ .Values.service.targetPort }}
     protocol: TCP
     name: http
     {{ if and (eq .Values.service.type "NodePort") (.Values.service.nodePort)  }}

--- a/charts/airbyte-webapp/values.yaml
+++ b/charts/airbyte-webapp/values.yaml
@@ -73,10 +73,12 @@ readinessProbe:
 
 ##  webapp.service.type The service type to use for the webapp service
 ##  webapp.service.port The service port to expose the webapp on
+##  webapp.service.targetPort The target port of the webapp service - useful in situations where it needs to be proxied via another pod
 ##  webapp.service.annotations Annotations for the webapp service resource
 service:
   type: ClusterIP
   port: 80
+  targetPort: http
   annotations: {}
 
 ## Web app resource requests and limits
@@ -145,7 +147,6 @@ api:
 ##  webapp.fullstory.enabled Whether or not to enable fullstory
 fullstory:
   enabled: false
-
 
 ##  webapp.extraVolumeMounts [array] Additional volumeMounts for webapp container(s).
 ## Examples (when using `webapp.containerSecurityContext.readOnlyRootFilesystem=true`):
@@ -243,9 +244,6 @@ secrets: {}
 #   INTERNAL_API_HOST: airbyte-server-svc:8001
 
 env_vars: {}
-
-
-
 
 ## extraSelectorLabels [object] - use to specify own additional selector labels for deployment
 extraSelectorLabels: {}

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -343,6 +343,7 @@ Helm chart to deploy airbyte
 | webapp.secrets | object | `{}` | Supply additional secrets to container |
 | webapp.service.annotations | object | `{}` | Annotations for the webapp service resource |
 | webapp.service.port | int | `80` | The service port to expose the webapp on |
+| webapp.service.targetPort | string OR int | `"http"` |  |
 | webapp.service.type | string | `"ClusterIP"` | The service type to use for the webapp service |
 | webapp.tolerations | list | `[]` | Tolerations for webapp pod assignment, see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | worker.activityInitialDelayBetweenAttemptsSeconds | string | `""` |  |

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -132,7 +132,7 @@ webapp:
     fsGroup: 101
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=101(nginx)
     runAsUser: 101
@@ -179,6 +179,8 @@ webapp:
     type: ClusterIP
     # -- The service port to expose the webapp on
     port: 80
+    # -- The target port of the webapp service - useful in situations where it needs to be proxied via another pod
+    targetPort: http
     # -- Annotations for the webapp service resource
     annotations: {}
 
@@ -358,7 +360,7 @@ pod-sweeper:
     fsGroup: 1001
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1001(anon)
     runAsUser: 1001
@@ -466,7 +468,7 @@ server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -648,7 +650,7 @@ worker:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -787,7 +789,7 @@ workload-launcher:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -929,7 +931,7 @@ metrics:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1051,7 +1053,7 @@ airbyte-bootloader:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1182,7 +1184,7 @@ temporal:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(temporal)
     runAsUser: 1000
@@ -1300,7 +1302,7 @@ postgresql:
     fsGroup: 70
   containerSecurityContext:
     # -- Ensures the container will run with a non-root user
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=70(postgres)
     runAsUser: 70
@@ -1394,7 +1396,7 @@ cron:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1565,7 +1567,7 @@ connector-builder-server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1660,7 +1662,7 @@ airbyte-api-server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1774,7 +1776,7 @@ keycloak:
     fsGroup: 0
 
   initContainerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=70(postgres)
     runAsUser: 70
@@ -1785,9 +1787,9 @@ keycloak:
       drop: ["ALL"]
     seccompProfile:
       type: RuntimeDefault
-    
+
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(keycloak)
     runAsUser: 1000
@@ -1819,7 +1821,7 @@ keycloak-setup:
     fsGroup: 1000
 
   initContainerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # gid=100(curl_user)
     runAsUser: 100
@@ -1832,7 +1834,7 @@ keycloak-setup:
       type: RuntimeDefault
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1874,7 +1876,7 @@ workload-api-server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false 
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -132,7 +132,7 @@ webapp:
     fsGroup: 101
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=101(nginx)
     runAsUser: 101
@@ -360,7 +360,7 @@ pod-sweeper:
     fsGroup: 1001
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1001(anon)
     runAsUser: 1001
@@ -468,7 +468,7 @@ server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -650,7 +650,7 @@ worker:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -789,7 +789,7 @@ workload-launcher:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -931,7 +931,7 @@ metrics:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1053,7 +1053,7 @@ airbyte-bootloader:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1184,7 +1184,7 @@ temporal:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(temporal)
     runAsUser: 1000
@@ -1302,7 +1302,7 @@ postgresql:
     fsGroup: 70
   containerSecurityContext:
     # -- Ensures the container will run with a non-root user
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=70(postgres)
     runAsUser: 70
@@ -1396,7 +1396,7 @@ cron:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1567,7 +1567,7 @@ connector-builder-server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1662,7 +1662,7 @@ airbyte-api-server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1776,7 +1776,7 @@ keycloak:
     fsGroup: 0
 
   initContainerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=70(postgres)
     runAsUser: 70
@@ -1789,7 +1789,7 @@ keycloak:
       type: RuntimeDefault
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(keycloak)
     runAsUser: 1000
@@ -1821,7 +1821,7 @@ keycloak-setup:
     fsGroup: 1000
 
   initContainerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # gid=100(curl_user)
     runAsUser: 100
@@ -1834,7 +1834,7 @@ keycloak-setup:
       type: RuntimeDefault
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000
@@ -1876,7 +1876,7 @@ workload-api-server:
     fsGroup: 1000
 
   containerSecurityContext:
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: false 
     runAsNonRoot: true
     # uid=1000(airbyte)
     runAsUser: 1000


### PR DESCRIPTION
## What

Make the `targetPort` of the webapp service configurable as a Helm chart value.

## How

This is achieved by adding `webapp.service.targetPort` as configurable value in values.yaml of the airbyte & webapp charts.

## Recommended reading order

1. charts/airbyte/README.md
2. charts/airbyte-webapp/values.yaml
3. charts/airbyte-webapp/README.md
4. charts/airbyte-webapp/values.yaml
5. charts/airbyte-webapp/templates/service.yaml

## Can this PR be safely reverted and rolled back?

- [X] YES 💚
- [ ] NO ❌
