### PR TITLE
Use container_name for docker-proxy too

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ x-logging: &default-logging
 services:
   docker-proxy:
       image: alpine/socat
+      container_name: docker-proxy
       command: -t 900 TCP-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock
       ports: 
         - "2375"


### PR DESCRIPTION

## What
Avoid name resolution issues in docker compose and be consistent with other containers.



## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
