### PR TITLE
Add missing env variable(AIRBYTE_API_HOST) to docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -159,6 +159,7 @@ services:
     container_name: airbyte-server
     restart: unless-stopped
     environment:
+      - AIRBYTE_API_HOST=${AIRBYTE_API_HOST}
       - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
       - AIRBYTE_VERSION=${VERSION}
       - AUTO_DETECT_SCHEMA=${AUTO_DETECT_SCHEMA}


### PR DESCRIPTION
## What
- The public API is not working with the docker-compose deployment. Related issue: https://github.com/airbytehq/airbyte/issues/37848

## How
- Adding the missing env variable to the docker-compose file for the airbyte-server container fixes the issue.

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [X] YES 💚
- [ ] NO ❌
