### PR TITLE
Add nodeSelector, tolerations, and affinity to minio create bucket pod

### DIFF
--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -164,4 +164,16 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-airbyte-env
               key: MINIO_ENDPOINT
+      {{- with .Values.minio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
## What
The minio create bucket pod does not inherit the tolerations and affinities the main minio does. We need the ability to define where this pod runs. In our install this pod does not run and the helm chart leaves an error condition. 

## How
The create bucket pod uses the same settings as the other minio pods.

## Recommended reading order
1. `x.kt`
2. `y.kt`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [ X ] YES 💚
- [ ] NO ❌
