### PR TITLE
[pod-sweeper] Skip Pending pods that haven't started yet

### DIFF
--- a/charts/airbyte-pod-sweeper/templates/configmap.yaml
+++ b/charts/airbyte-pod-sweeper/templates/configmap.yaml
@@ -52,6 +52,10 @@ data:
                 POD_STATUS=`echo $POD | cut -d " " -f 2`
                 POD_DATE_STR=`echo $POD | cut -d " " -f 3`
                 POD_START_DATE_STR=`echo $POD | cut -d " " -f 4`
+                if [ "$POD_STATUS" = "Pending" ] && [ -z "$POD_DATE_STR" ] && [ -z "$POD_START_DATE_STR" ]; then
+                  echo "Pod ${POD_NAME} hasn't started yet. Skipping..."
+                  continue
+                fi
                 POD_DATE=`date -d ${POD_DATE_STR:-$POD_START_DATE_STR} '+%s'`
                 if [ -n "${RUNNING_TTL_MINUTES}" ] && [ "$POD_STATUS" = "Running" ]; then
                   if [ "$POD_DATE" -lt "$RUNNING_DATE" ]; then


### PR DESCRIPTION
## What
Solves issue:
```
date: invalid date '+%s'
/script/sweep-pod.sh: line 53: [: : integer expression expected
```

## How
Some pods might be in `Pending` status when sweep-pod.sh is running `get_job_pods`

In shell session below you can see how statuses and dates may change
```bash
➜ [21:46:48] $ get_job_pods
 destination-s3-write-2454-0-hkttw Pending
 orchestrator-repl-job-2454-attempt-0 Running 2024-05-20T19:46:08Z 2024-05-20T19:46:05Z
 source-appstore-read-2454-0-djwvt Pending
➜ [21:46:49] $ get_job_pods
 destination-s3-write-2454-0-hkttw Pending 2024-05-20T19:47:22Z 2024-05-20T19:47:19Z
 orchestrator-repl-job-2454-attempt-0 Running 2024-05-20T19:46:08Z 2024-05-20T19:46:05Z
 source-appstore-read-2454-0-djwvt Pending 2024-05-20T19:47:21Z 2024-05-20T19:47:19Z
➜ [21:47:22] $ get_job_pods
 destination-s3-write-2454-0-hkttw Pending 2024-05-20T19:47:22Z 2024-05-20T19:47:19Z
 orchestrator-repl-job-2454-attempt-0 Running 2024-05-20T19:46:08Z 2024-05-20T19:46:05Z
 source-appstore-read-2454-0-djwvt Running 2024-05-20T19:47:21Z 2024-05-20T19:47:19Z
➜ [21:47:37] $ get_job_pods
 destination-s3-write-2454-0-hkttw Succeeded 2024-05-20T19:47:53Z 2024-05-20T19:47:19Z
 orchestrator-repl-job-2454-attempt-0 Succeeded 2024-05-20T19:47:53Z 2024-05-20T19:46:05Z
 source-appstore-read-2454-0-djwvt Succeeded 2024-05-20T19:47:43Z 2024-05-20T19:47:19Z
```

Extra condition skips pods that haven't started yet. Pod might be longer in `Pending` state e.g. when it is necessary to spawn new Kubernetes node to run that pod.

## Recommended reading order
1. `charts/airbyte-pod-sweeper/templates/configmap.yaml`

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
