### PR TITLE
feat: Add capability to disable minio deployment in airbyte chart

### DIFF
--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (lower (default "" .Values.global.storage.type)) "minio")}}
+{{- if .Values.minio.enabled }}
 apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: StatefulSet
 metadata:

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -77,16 +77,32 @@ global:
     # -- The database user
     user: ""
     # -- The key within `secretName` where the user is stored
-    #userSecretKey: "" # e.g. "database-user"
+    # userSecretKey: "" # e.g. "database-user"
 
     # -- The database password
     password: ""
     # -- The key within `secretName` where the password is stored
-    #passwordSecretKey: "" # e.g."database-password"
+    # passwordSecretKey: "" # e.g."database-password"
 
   storage:
-    type: minio # default storage used
-    # TODO: Add full configuration here
+    type: minio # s3 | gcs | minio - default | (local)
+    # storageSecretName: airbyte-config-secrets
+    # bucket:
+    #   activityPayload: airbyte-storage
+    #   log: airbyte-storage
+    #   state: airbyte-storage
+    #   workloadOutput: airbyte-storage
+    # s3:
+    #   authenticationType: credentials # credentials | instanceProfile
+    #   accessKeyIdSecretKey: aws-secret-manager-access-key-id
+    #   secretAccessKeySecretKey: aws-secret-manager-secret-access-key
+    # gcs:
+    #   project: <gcp-project>
+    #   credentialsPath: <gcs-credentials> # this is actually be path to file in mount https://docs.airbyte.com/deploying-airbyte/on-kubernetes-via-helm#external-logs-with-gcs
+    # minio: # only include this if you are using an external minio deployment, otherwise, you can exclude this section entirely as long as you have the type set to minio
+    #   accessKeyIdSecretKey: minio-secret-manager-access-key-id # set to `minio` in your secrets if using local minio instance
+    #   secretAccessKeySecretKey: minio-secret-manager-secret-access-key # set to `minio123` in your secrets if using local minio instance
+    #   endpoint: <minio-endpoint> # set to http://airbyte-minio-svc:9000 if using local minio instance
 
   metrics:
     # -- The metric client to configure globally. Supports "otel"
@@ -1414,6 +1430,8 @@ externalDatabase:
 ## @section Logs parameters
 
 minio:
+  # -- Switch to enable or disable the minio helm chart
+  enabled: true
   image:
     # -- Minio image used by Minio helm chart
     repository: minio/minio


### PR DESCRIPTION
## What
Actually it is possible to use an external minio but the internal minio is still deployed.

## How
I duplicate the postgresql logical to add the capability to disable minio deployment in `minio.enabled` key.

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
