### PR TITLE
fix(helm): correctly format imagePullSecrets for metrics deployment

### DIFF
--- a/charts/airbyte-metrics/templates/deployment.yaml
+++ b/charts/airbyte-metrics/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.global.imagePullSecrets }}
-          {{- printf "- name: %s" .name | nindent 2 }}
+          {{- printf "- name: %s" .name | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.nodeSelector }}


### PR DESCRIPTION
## What

```
Error: YAML parse error on airbyte/charts/metrics/templates/deployment.yaml: error converting YAML to JSON: yaml: line 27: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 27: did not find expected key
YAML parse error on airbyte/charts/metrics/templates/deployment.yaml
```

Before:
```
    spec:
      serviceAccountName: airbyte-admin
      imagePullSecrets:
  - name: dockerhub
      nodeSelector:
        dedicated: root-node
```

After:
```
    spec:
      serviceAccountName: airbyte-admin
      imagePullSecrets:
        - name: dockerhub # <-- CHANGE HERE
      nodeSelector:
        dedicated: root-node
```

## How
- fix yaml indentation to allow correct parsing

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
