### PR TITLE
fix: Cron Chart deployment extraContainers

### DIFF
--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -176,7 +176,7 @@ spec:
           {{- end }}
 
         {{- if .Values.extraContainers }}
-          {{ toYaml .Values.extraContainers | nindent 6 }}
+          {{ toYaml .Values.extraContainers | nindent 8 }}
         {{- end }}
         {{- if .Values.global.extraContainers }}
           {{ toYaml .Values.global.extraContainers | nindent 8 }}


### PR DESCRIPTION
Fixes an issue that causes the chart yaml not to be rendered when passing `cron.extraContainers`

## What
When I pass `cron.extraContainers`, the chart fails to render with this error:
```sh
error converting YAML to JSON: yaml: line 166: did not find expected key
```

## How
Changing `nindent` from 6 to 8 (mirroring the global.extraContainers config)

## Recommended reading order
airbyte-platform/charts/airbyte-cron/templates/deployment.yaml

## Can this PR be safely reverted and rolled back?
- [x ] YES 💚
- [ ] NO ❌

---  

## Before changing:
<img width="1594" alt="image" src="https://github.com/user-attachments/assets/42654264-1322-414c-9852-47735b9a2dad">

## After changing
Command runs successfuly, resulting in the following manifest

<img width="680" alt="image" src="https://github.com/user-attachments/assets/a0a44ec8-e007-45aa-b2fe-01c6de0832f0">

