### PR TITLE
patch verison bump for aws-java-sdk

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -59,8 +59,8 @@ apache-cxf-core = { module = "org.apache.cxf:cxf-core", version = "3.4.2" }
 apache-mime4j-core = { module = "org.apache.james:apache-mime4j-core", version = "0.8.10" } # Transitive dependency of keycloak. Forced upgrade to 0.8.10 from 0.8.9
 appender-log4j2 = { module = "com.therealvan:appender-log4j2", version = "5.3.2" }
 assertj-core = { module = "org.assertj:assertj-core", version = "3.21.0" }
-aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.701" }
-aws-java-sdk-sts = {module = "com.amazonaws:aws-java-sdk-sts", version = "1.12.701"}
+aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.746" }
+aws-java-sdk-sts = {module = "com.amazonaws:aws-java-sdk-sts", version = "1.12.746"}
 aws-secretsmanager-caching-java = { module = "com.amazonaws.secretsmanager:aws-secretsmanager-caching-java", version = "1.0.2" }
 bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncycastle" }
 bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bouncycastle" }


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->
[This GitHub Issue](https://github.com/aws/aws-sdk-java/issues/3062) for the aws java sdk discusses how version 1.12.746 of the sdk is the first version that supports the EKS pod identity add-on. Seeing how airbyte is moving to kubernetes deployment of it's open source platform, it makes sense for this sdk version to be updated to support EKS pod identity deployments.
## How
<!--
* Describe how code changes achieve the solution.
-->
Simply updating the aws-java-sdk dependency to be on version `1.12.746` will enable support for EKS pod identity to work. 
This [page](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html) shows which AWS SDKs and versions support EKS pod identity.

## Recommended reading order

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
