### PR TITLE
Use `crossorigin="use-credentials"` for manifest files

### DIFF
--- a/airbyte-webapp/index.html
+++ b/airbyte-webapp/index.html
@@ -12,7 +12,7 @@
     <meta name="airbyte:sec-token" content="c82db11b-64df-413d-aba8-ee66b99c046f">
     <meta name="airbyte:version" content=%VERSION%>
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
     <link rel="stylesheet" href="/index.css">
     <title>Airbyte</title>
   </head>

--- a/airbyte-webapp/oauth-callback.html
+++ b/airbyte-webapp/oauth-callback.html
@@ -12,7 +12,7 @@
     <meta name="airbyte:sec-token" content="c82db11b-64df-413d-aba8-ee66b99c046f">
     <meta name="airbyte:version" content=%VERSION%>
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
     <link rel="stylesheet" href="/index.css">
     <title>Airbyte</title>
   </head>


### PR DESCRIPTION
When running Airbyte behind an authentication proxy (in my case, GCP's Identity-Aware Proxy), the `manifest.json` request will always fail with a CORS error, like:

```
Access to manifest at 'https://accounts.google.com/o/oauth2/v2/auth?client_id=465372...' 
(redirected from 'https://airbyte.mydomain.com/manifest.json') from origin
'https://airbyte.mydomain.com' has been blocked by CORS policy: No
'Access-Control-Allow-Origin' header is present on the requested resource.
```