### PR TITLE
Fix indentation

### DIFF
--- a/charts/airbyte-temporal-ui/templates/deployment.yaml
+++ b/charts/airbyte-temporal-ui/templates/deployment.yaml
@@ -117,8 +117,8 @@ spec:
         {{- if .Values.global.extraContainers }}
         {{ toYaml .Values.global.extraContainers | nindent 6 }}
         {{- end }}
-        securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-        volumes:
-        {{- if .Values.extraVolumes }}
-    {{ toYaml .Values.extraVolumes | nindent 6 }}
-        {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      {{- if .Values.extraVolumes }}
+      {{ toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}


### PR DESCRIPTION
The current rendered template is:

```
        volumeMounts:
        securityContext:
        fsGroup: 1000
        volumes:
```