### PR TITLE
fix: add tolerations during reset pod creation

### DIFF
--- a/airbyte-workload-launcher/src/main/kotlin/pods/factories/ReplicationPodFactory.kt
+++ b/airbyte-workload-launcher/src/main/kotlin/pods/factories/ReplicationPodFactory.kt
@@ -153,6 +153,7 @@ data class ReplicationPodFactory(
       .withImagePullSecrets(imagePullSecrets)
       .withVolumes(replicationVolumes.allVolumes)
       .withNodeSelector<Any, Any>(nodeSelectors)
+      .withTolerations(tolerations)
       .withAutomountServiceAccountToken(false)
       .withSecurityContext(workloadSecurityContextProvider.defaultPodSecurityContext())
       .endSpec()


### PR DESCRIPTION
## What
While replication pods took tolerations into consideration, reset pods were created without tolerations, which resulted in Pending pods due to node taints.

## How
Create reset pods with provided tolerations, just like replication pods. Closes https://github.com/airbytehq/airbyte/issues/48380

## Recommended reading order
1. `airbyte-workload-launcher/src/main/kotlin/pods/factories/ReplicationPodFactory.kt`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
