### PR TITLE
fix: add datasources.config for airbyte-workload-launcher to fix breaking JDBC connection

### DIFF
--- a/airbyte-workload-launcher/src/main/resources/application-oss.yml
+++ b/airbyte-workload-launcher/src/main/resources/application-oss.yml
@@ -7,6 +7,18 @@ airbyte:
     persistence: ${SECRET_PERSISTENCE:TESTING_CONFIG_DB_TABLE}
 
 datasources:
+  config:
+    connection-test-query: SELECT 1
+    connection-timeout: 30000
+    maximum-pool-size: ${CONFIG_DB_MAX_POOL_SIZE:10}
+    minimum-idle: 0
+    idle-timeout: 600000
+    initialization-fail-timeout: -1 # Disable fail fast checking to avoid issues due to other pods not being started in time
+    url: ${DATABASE_URL}
+    driverClassName: org.postgresql.Driver
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+    leak-detection-threshold: 40000 # This should be slightly higher than the connection-timeout setting but not too high to avoid false positives and negatives.
   local-secrets:
     connection-test-query: SELECT 1
     connection-timeout: 30000


### PR DESCRIPTION
## What
airbyte-workload-launcher was breaking when using custom database connection, i see this config is missing, i hope it will be enough

## How
Adding missing configuration

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
