### PR TITLE
Fix typo: version

### DIFF
--- a/airbyte-webapp/packages/vite-plugins/environment-variables.ts
+++ b/airbyte-webapp/packages/vite-plugins/environment-variables.ts
@@ -61,7 +61,7 @@ export function environmentVariables(): Plugin {
       return {
         define: {
           ...processEnv,
-          // This lets us set the verison in a meta tag in index.html
+          // This lets us set the version in a meta tag in index.html
           "import.meta.env.VERSION": version,
         },
       };

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -1037,7 +1037,7 @@
   "settings.workspace.usage.title": "Workspace usage",
   "settings.workspace.usage.tooltip": "Workspace usage is measured in <lnk>credits</lnk>.",
   "settings.connector.editDefinition.title": "Edit connector definition",
-  "settings.connector.editDefinition.updateAvailable": "A new verison of {connectorName} is available: {latestVersion}",
+  "settings.connector.editDefinition.updateAvailable": "A new version of {connectorName} is available: {latestVersion}",
   "settings.connector.editDefinition.displayName": "Connector display name",
   "settings.connector.editDefinition.dockerImage": "Docker image",
   "settings.connector.editDefinition.dockerImageTag": "Docker image tag",


### PR DESCRIPTION
## What

Fixed typo.

![image](https://github.com/user-attachments/assets/4be4e989-b713-46bb-b6d3-c248daea3380)


## Recommended reading order
1. `airbyte-webapp/src/locales/en.json`
2. `airbyte-webapp/packages/vite-plugins/environment-variables.ts`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
