### PR TITLE
ASRE-550: Fix WORKLOAD_API_BEARER_TOKEN issue

### DIFF
--- a/charts/airbyte/templates/_database.tpl
+++ b/charts/airbyte/templates/_database.tpl
@@ -207,11 +207,11 @@ Renders all of the common environment variables which provide database credentia
 Renders a set of database secrets to be included in the shared Airbyte secret
 */}}
 {{- define "airbyte.database.secrets" }}
-{{ $user := (include "airbyte.database.user" .)}}
+{{ $user := (include "airbyte.database.user" .) | trim }}
 {{- if not (empty $user) }}
 DATABASE_USER: {{ $user }}
 {{- end }}
-{{ $password := (include "airbyte.database.password" .)}}
+{{ $password := (include "airbyte.database.password" .) | trim }}
 {{- if not (empty $password) }}
 DATABASE_PASSWORD: {{ $password }}
 {{- end}}

--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -15,4 +15,4 @@ stringData:
   KEYCLOAK_ADMIN_USER: {{ .Values.keycloak.auth.adminUsername | quote }}
   KEYCLOAK_ADMIN_PASSWORD: {{ .Values.keycloak.auth.adminPassword | quote }}
   {{- end }}
-  WORKLOAD_API_BEARER_TOKEN: {{ index ".Values.workload-api.bearerToken" | quote }}
+  WORKLOAD_API_BEARER_TOKEN: {{ index .Values "workload-api-server" "bearerToken" | quote }}


### PR DESCRIPTION
## What
This change updates the WORKLOAD_API_BEARER_TOKEN to use a dynamic value by referencing bearerToken in the workload-api and workload-api-server sections from the Helm values file.

## How
This modification uses Helm's index function to dynamically fetch the bearerToken values from .Values.workload-api and .Values.workload-api-server, ensuring that the correct token is used for authentication. The tokens are now quoted properly for use in Kubernetes configurations.

Before:
`WORKLOAD_API_BEARER_TOKEN: {{ index ".Values.workload-api.bearerToken" | quote }}`
After:
`WORKLOAD_API_BEARER_TOKEN: {{ index .Values "workload-api-server" "bearerToken" | quote }}`

## Can this PR be safely reverted and rolled back?

- [X ] YES 💚
- [ ] NO ❌
