### PR TITLE
Add postgresql resources to helm chart

### DIFF
--- a/charts/airbyte/templates/airbyte-db.yaml
+++ b/charts/airbyte/templates/airbyte-db.yaml
@@ -60,6 +60,9 @@ spec:
           volumeMounts:
             - name: airbyte-volume-db
               mountPath: /var/lib/postgresql/data
+          {{- if .Values.postgresql.resources }}
+          resources: {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          {{- end }}
       {{- with .Values.postgresql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1706,6 +1706,21 @@ postgresql:
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
+  # -- postgresql pod resources requests and limits
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 1
+    ##    memory: 2Gi
+    # -- The resources limits for the postgresql container
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    memory: 2Gi
+    ##    cpu: 200m
+    # -- The requested resources for the postgresql container
+    requests: {}
+
 # External PostgreSQL configuration, All of these values are only used when postgresql.enabled is set to false
 externalDatabase:
   # -- Database host

--- a/charts/v2/airbyte/templates/airbyte-db.yaml
+++ b/charts/v2/airbyte/templates/airbyte-db.yaml
@@ -60,6 +60,9 @@ spec:
           volumeMounts:
             - name: airbyte-volume-db
               mountPath: /var/lib/postgresql/data
+          {{- if .Values.postgresql.resources }}
+          resources: {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          {{- end }}
       {{- with .Values.postgresql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/v2/airbyte/values.yaml
+++ b/charts/v2/airbyte/values.yaml
@@ -2025,6 +2025,21 @@ postgresql:
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
+  # -- postgresql pod resources requests and limits
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 1
+    ##    memory: 2Gi
+    # -- The resources limits for the postgresql container
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    memory: 2Gi
+    ##    cpu: 200m
+    # -- The requested resources for the postgresql container
+    requests: {}
+
 minio:
   secretName: ""
 


### PR DESCRIPTION
## What
 The chart failed to run on clusters configured with resource quota.
 Need to add resources to the database pod in the helm chart. 


## How
* Add resources to the database pod in the helm chart.

## Recommended reading order
1. `x.kt`
2. `y.kt`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [X ] YES 💚
- [ ] NO ❌
