### PR TITLE
ASRE-931: Add new variable shareProcessNamespace

### DIFF
--- a/charts/airbyte-bootloader/README.md
+++ b/charts/airbyte-bootloader/README.md
@@ -35,7 +35,6 @@ Helm chart to deploy airbyte-bootloader
 | global.secretName | string | `""` |  |
 | global.secrets | object | `{}` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
-| global.shareProcessNamespace | string | `"false"` | the shareProcessNamespace field is used in a PodSpec to enable all containers within a pod to share the same process namespace. This allows containers to view and interact with each other's processes. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"airbyte/bootloader"` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/airbyte-bootloader/README.md
+++ b/charts/airbyte-bootloader/README.md
@@ -35,6 +35,7 @@ Helm chart to deploy airbyte-bootloader
 | global.secretName | string | `""` |  |
 | global.secrets | object | `{}` |  |
 | global.serviceAccountName | string | `"placeholderServiceAccount"` |  |
+| global.shareProcessNamespace | string | `"false"` | the shareProcessNamespace field is used in a PodSpec to enable all containers within a pod to share the same process namespace. This allows containers to view and interact with each other's processes. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"airbyte/bootloader"` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/airbyte-bootloader/README.md
+++ b/charts/airbyte-bootloader/README.md
@@ -43,5 +43,6 @@ Helm chart to deploy airbyte-bootloader
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
 | secrets | object | `{}` |  |
+| shareProcessNamespace | string | `"false"` | the shareProcessNamespace field is used in a PodSpec to enable all containers within a pod to share the same process namespace. This allows containers to view and interact with each other's processes. |
 | tolerations | list | `[]` |  |
 

--- a/charts/airbyte-bootloader/templates/pod.yaml
+++ b/charts/airbyte-bootloader/templates/pod.yaml
@@ -18,7 +18,7 @@ metadata:
       {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.global.shareProcessNamespace }}
+  {{- if .Values.shareProcessNamespace }}
   shareProcessNamespace: true
   {{- end }}
   serviceAccountName: {{ .Values.global.serviceAccountName }}

--- a/charts/airbyte-bootloader/templates/pod.yaml
+++ b/charts/airbyte-bootloader/templates/pod.yaml
@@ -18,6 +18,9 @@ metadata:
       {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.global.shareProcessNamespace }}
+  shareProcessNamespace: true
+  {{- end }}
   serviceAccountName: {{ .Values.global.serviceAccountName }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/airbyte-bootloader/values.yaml
+++ b/charts/airbyte-bootloader/values.yaml
@@ -7,7 +7,6 @@ global:
   serviceAccountName: placeholderServiceAccount
   deploymentMode: oss
   secretName: ""
-  shareProcessNamespace: false  
   database:
     secretName: ""
     secretValue: ""

--- a/charts/airbyte-bootloader/values.yaml
+++ b/charts/airbyte-bootloader/values.yaml
@@ -7,6 +7,7 @@ global:
   serviceAccountName: placeholderServiceAccount
   deploymentMode: oss
   secretName: ""
+  shareProcessNamespace: false  
   database:
     secretName: ""
     secretValue: ""

--- a/charts/airbyte-bootloader/values.yaml
+++ b/charts/airbyte-bootloader/values.yaml
@@ -35,6 +35,8 @@ image:
   repository: airbyte/bootloader
   pullPolicy: IfNotPresent
 
+shareProcessNamespace: false
+
 ##  podAnnotations [object] Add extra annotations to the bootloader pod
 ##
 podAnnotations: {}

--- a/charts/airbyte-temporal-ui/templates/deployment.yaml
+++ b/charts/airbyte-temporal-ui/templates/deployment.yaml
@@ -117,8 +117,8 @@ spec:
         {{- if .Values.global.extraContainers }}
         {{ toYaml .Values.global.extraContainers | nindent 6 }}
         {{- end }}
-        securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-        volumes:
-        {{- if .Values.extraVolumes }}
-    {{ toYaml .Values.extraVolumes | nindent 6 }}
-        {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      {{- if .Values.extraVolumes }}
+  {{ toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/airbyte/templates/_database.tpl
+++ b/charts/airbyte/templates/_database.tpl
@@ -207,11 +207,11 @@ Renders all of the common environment variables which provide database credentia
 Renders a set of database secrets to be included in the shared Airbyte secret
 */}}
 {{- define "airbyte.database.secrets" }}
-{{ $user := (include "airbyte.database.user" .)}}
+{{ $user := (include "airbyte.database.user" .) | trim }}
 {{- if not (empty $user) }}
 DATABASE_USER: {{ $user }}
 {{- end }}
-{{ $password := (include "airbyte.database.password" .)}}
+{{ $password := (include "airbyte.database.password" .) | trim }}
 {{- if not (empty $password) }}
 DATABASE_PASSWORD: {{ $password }}
 {{- end}}

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -102,9 +102,9 @@ data:
   JOB_MAIN_CONTAINER_MEMORY_LIMIT: {{ ((.Values.global.jobs.resources | default dict).limits | default dict).memory | default "" | quote }}
   JOB_MAIN_CONTAINER_MEMORY_REQUEST: {{ ((.Values.global.jobs.resources | default dict).requests | default dict).memory | default "" | quote }}
 
-  {{- if $.Values.global.jobs.kube.main_container_image_pull_secret }}
+{{- if and $.Values.global.jobs.kube.main_container_image_pull_secret (ne $.Values.global.jobs.kube.main_container_image_pull_secret "") }}
   JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET: {{ $.Values.global.jobs.kube.main_container_image_pull_secret }}
-  {{- end }}
+{{- end }}
   JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.29.15.001"
 
   JOB_KUBE_LOCAL_VOLUME_ENABLED: {{ .Values.global.jobs.local.volume.enabled | quote }}

--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -15,4 +15,4 @@ stringData:
   KEYCLOAK_ADMIN_USER: {{ .Values.keycloak.auth.adminUsername | quote }}
   KEYCLOAK_ADMIN_PASSWORD: {{ .Values.keycloak.auth.adminPassword | quote }}
   {{- end }}
-  WORKLOAD_API_BEARER_TOKEN: {{ index ".Values.workload-api.bearerToken" | quote }}
+  WORKLOAD_API_BEARER_TOKEN: {{ index .Values "workload-api-server" "bearerToken" | quote }}


### PR DESCRIPTION
## What
This PR introduces the shareProcessNamespace field in the PodSpec. When enabled, this feature allows all containers within a pod to share the same process namespace. This means containers can view and interact with each other's processes, enhancing communication and debugging capabilities between containers in the same pod.
## How

- Added the shareProcessNamespace field to the PodSpec structure.
- Updated the pod creation logic to check for this field and configure the process namespace accordingly.
- Adjusted the container runtime settings to support shared process namespaces.
- Included tests to verify that containers can indeed share the process namespace when the field is enabled.
- Updated documentation to explain how to use shareProcessNamespace in PodSpec.


## Can this PR be safely reverted and rolled back?
- [X ] YES 💚
- [ ] NO ❌
