### PR TITLE
Fix wrong values set for JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET ConfigMap key

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -106,7 +106,7 @@ data:
   {{- $imagePullSecrets = append $imagePullSecrets $.Values.global.jobs.kube.main_container_image_pull_secret }}
   {{- end }}
 
-  JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET: {{ join "," $imagePullSecrets }}
+  JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET: {{ join "," ($imagePullSecrets | uniq) | quote }}
 
   JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.29.15.001"
 


### PR DESCRIPTION
## What
Fixes a regression caused by https://github.com/airbytehq/airbyte-platform/commit/201b8e8e8e19b556c3a49c4507245b08953dff31 (causes issue: https://github.com/airbytehq/airbyte/issues/52034)

When specifying common values in `global.imagePullSecrets` and `global.jobs.kube.main_container_image_pull_secret`, the duplicates would cause the application to fail at runtime.

Also, when not specifying any pull secrets (either via `global.imagePullSecrets` or `global.jobs.kube.main_container_image_pull_secret`), an empty string would be set for the value of the `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET` configmap key, causing to end up as `null` in the configmap.

## How
- Dedupes the names of the pull secrets before joining them, using the `uniq` function
- Quotes the values, using the `quote` function. If the result of the concatenation of the list resolves to an empty string, this way the entry will still end up in the configmap. Otherwise, it will end up being interpreted as `null` and will actually not be present in the configmap.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
