### PR TITLE
SELECT specific columns from ORGANIZATION table in getOrganization

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/OrganizationPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/OrganizationPersistence.java
@@ -58,10 +58,18 @@ public class OrganizationPersistence {
    */
   public Optional<Organization> getOrganization(final UUID organizationId) throws IOException {
     final Result<Record> result = database.query(ctx -> ctx
-        .select(asterisk())
-        .from(ORGANIZATION)
-        .leftJoin(SSO_CONFIG).on(ORGANIZATION.ID.eq(SSO_CONFIG.ORGANIZATION_ID))
-        .where(ORGANIZATION.ID.eq(organizationId)).fetch());
+            .select(
+                    ORGANIZATION.ID,
+                    ORGANIZATION.NAME,
+                    ORGANIZATION.EMAIL,
+                    ORGANIZATION.USER_ID,
+                    ORGANIZATION.CREATED_AT,
+                    ORGANIZATION.UPDATED_AT,
+                    SSO_CONFIG.KEYCLOAK_REALM
+            )
+            .from(ORGANIZATION)
+            .leftJoin(SSO_CONFIG).on(ORGANIZATION.ID.eq(SSO_CONFIG.ORGANIZATION_ID))
+            .where(ORGANIZATION.ID.eq(organizationId)).fetch());
 
     if (result.isEmpty()) {
       return Optional.empty();


### PR DESCRIPTION
## What

During Airbyte helm upgrade from 1.2.0 to 1.4.0, a type mismatch error occurred between code and database schema, causing web server access failure.

Root Cause
- Organization table's `tombstone` column contains UUID values
- Code attempts to read this field as boolean type
- Type conversion failure triggers 500 error on `/api/v1/instance_configuration` endpoint
- This occurs during organization data fetch operations

Migration Issue
- Database schema changes were required but not properly applied
- Flyway migration V0_50_24_003 should have added new columns:
   - 'pba' column
   - 'org_level_billing' column
- Incomplete migration led to schema inconsistency in tombstone column

Web server became inaccessible due to the failed type conversion between UUID and boolean in the organization table.

Error message:
```
Caused by: org.postgresql.util.PSQLException: Cannot cast to boolean: "4f74841b-3fa8-476c-9102-67a80be8a042"
at org.postgresql.jdbc.BooleanTypeUtil.cannotCoerceException(BooleanTypeUtil.java:99)
```

## How
Modified organization queries to explicitly select required columns instead of using asterisk(*):

Removed select(asterisk()) to avoid automatic mapping of problematic tombstone field
Added explicit column selection for required fields only
This prevents the type mismatch between UUID and boolean

## Recommended reading order

- OrganizationPersistence.java

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
