### PR TITLE
Resolve airbytehq/airbyte#55172

### DIFF
--- a/charts/airbyte/templates/airbyte-db.yaml
+++ b/charts/airbyte/templates/airbyte-db.yaml
@@ -81,5 +81,5 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 500Mi
+          storage: {{ .Values.postgresql.storage.volumeClaimValue }}
 {{- end }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1668,6 +1668,10 @@ postgresql:
   postgresqlPassword: airbyte
   # -- Airbyte Postgresql database
   postgresqlDatabase: db-airbyte
+
+  storage:
+    volumeClaimValue: 500Mi
+
   # fullnameOverride: *db-hostname
   ## This secret is used in case of postgresql.enabled=true and we would like to specify password for newly created postgresql instance
   # -- Name of an existing secret containing the PostgreSQL password ('postgresql-password' key)


### PR DESCRIPTION
## What

Make the size of the volume claimed by the internal postgresql database configurabile in the helm chart.

## How

Add a storage configuration to postgresql section in values.yaml, similar to what happens to minio.


```yaml
postgresql:
  ...
  storage:
    volumeClaimValue: 500Mi

```

I also suggest to raise the default value to 5Gi to have compatibility with most infrastructures (see https://github.com/airbytehq/airbyte/issues/55172)

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
