### PR TITLE
fix issue #49938: missing property in helm airbyte/value.yaml (helm v1.3.1)

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -189,6 +189,8 @@ global:
       ## JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET
       # -- image pull secret to use for job pod
       main_container_image_pull_secret: ""
+      # this service account should be explicitly set and could possibly be different from global.serviceAccountName
+      serviceAccountName: airbyte-admin
 
 ## @section Common Parameters
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->

there is a somewhat "breaking" change introduced by this commit. https://github.com/airbytehq/airbyte-platform/commit/02e3c972338cc8a63364528d137ae52beec2f4a0
I'm not sure the context of this commit, but as far as I understand, `global.serviceAccountName` should be used across each services in airbyte. 
however, if the purpose is to let "workload-launcher" to use its own serviceaccount, then `airbyte/values.yaml` should be updated because this is where most end-users refer to since there is no changelog for helm charts.

## How
<!--
* Describe how code changes achieve the solution.
-->
to fix this issue  https://github.com/airbytehq/airbyte/issues/49938
## Recommended reading order
1. `value.yaml`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
