### PR TITLE
Remove duplicate AB_JWT_SIGNATURE_SECRET env var in airbyte-workload-api-server deployment

### DIFF
--- a/charts/airbyte-workload-api-server/templates/deployment.yaml
+++ b/charts/airbyte-workload-api-server/templates/deployment.yaml
@@ -143,11 +143,6 @@ spec:
             secretKeyRef:
               name: {{ index .Values "workloadApi" "bearerTokenSecretName" | default (printf "%s-airbyte-secrets" .Release.Name ) }}
               key: {{ index .Values "workloadApi" "bearerTokenSecretKey" | default "WORKLOAD_API_BEARER_TOKEN" }}
-        - name: AB_JWT_SIGNATURE_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.global.auth.secretName | default "airbyte-auth-secrets" | quote }}
-              key: {{ .Values.global.auth.jwtSignatureSecretKey | default "jwt-signature-secret" | quote }}
         - name: MICRONAUT_ENVIRONMENTS
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## What
This PR fixes a deployment failure in `airbyte-workload-api-server` caused by a duplicate environment variable definition for `AB_JWT_SIGNATURE_SECRET`. The duplicate entries were preventing the Kubernetes patch from applying successfully.

## How
Remove the duplicate `AB_JWT_SIGNATURE_SECRET` entry


## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
