### PR TITLE
🐛 Fix Helm Charts: place volumes: inside the if condition

### DIFF
--- a/charts/airbyte-connector-builder-server/templates/deployment.yaml
+++ b/charts/airbyte-connector-builder-server/templates/deployment.yaml
@@ -198,7 +198,7 @@ spec:
         {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      volumes:
       {{- if .Values.extraVolumes }}
+      volumes:
 {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/airbyte-connector-rollout-worker/templates/deployment.yaml
+++ b/charts/airbyte-connector-rollout-worker/templates/deployment.yaml
@@ -233,7 +233,7 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      volumes:
       {{- if .Values.extraVolumes }}
+      volumes:
   {{ toYaml .Values.extraVolumes | nindent 6 }}
   {{- end }}

--- a/charts/airbyte-keycloak/templates/statefulset.yaml
+++ b/charts/airbyte-keycloak/templates/statefulset.yaml
@@ -178,8 +178,8 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 8 }}
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 10 }}
-      volumes:
       {{- if .Values.extraVolumes }}
+      volumes:
       {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:

--- a/charts/airbyte-metrics/templates/deployment.yaml
+++ b/charts/airbyte-metrics/templates/deployment.yaml
@@ -167,7 +167,7 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      volumes:
       {{- if .Values.extraVolumes }}
+      volumes:
       {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/airbyte-temporal-ui/templates/deployment.yaml
+++ b/charts/airbyte-temporal-ui/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
         {{ toYaml .Values.global.extraContainers | nindent 6 }}
         {{- end }}
         securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-        volumes:
         {{- if .Values.extraVolumes }}
+        volumes:
     {{ toYaml .Values.extraVolumes | nindent 6 }}
         {{- end }}

--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -163,10 +163,12 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or .Values.extraVolumes .Values.global.extraVolumes }}
       volumes:
       {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if .Values.global.extraVolumes }}
 {{ toYaml .Values.global.extraVolumes | nindent 6 }}
+        {{- end }}
       {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-connector-builder-server/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-connector-builder-server/deployment.yaml
@@ -163,8 +163,8 @@ spec:
         {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.connectorBuilderServer.podSecurityContext | nindent 8 }}
-      volumes:
       {{- if .Values.connectorBuilderServer.extraVolumes }}
+      volumes:
 {{ toYaml .Values.connectorBuilderServer.extraVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-connector-rollout-worker/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-connector-rollout-worker/deployment.yaml
@@ -165,8 +165,8 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 8 }}
       {{- end }}
       securityContext: {{- toYaml .Values.connectorRolloutWorker.podSecurityContext | nindent 8 }}
-      volumes:
       {{- if .Values.connectorRolloutWorker.extraVolumes }}
+      volumes:
   {{ toYaml .Values.connectorRolloutWorker.extraVolumes | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-keycloak/statefulset.yaml
+++ b/charts/v2/airbyte/templates/airbyte-keycloak/statefulset.yaml
@@ -165,8 +165,8 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 8 }}
       {{- end }}
       securityContext: {{- toYaml .Values.keycloak.podSecurityContext | nindent 10 }}
-      volumes:
       {{- if .Values.keycloak.extraVolumes }}
+      volumes:
       {{ toYaml .Values.keycloak.extraVolumes | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:

--- a/charts/v2/airbyte/templates/airbyte-metrics/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-metrics/deployment.yaml
@@ -101,8 +101,8 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.metrics.podSecurityContext | nindent 8 }}
-      volumes:
       {{- if .Values.metrics.extraVolumes }}
+      volumes:
       {{ toYaml .Values.metrics.extraVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-temporal-ui/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-temporal-ui/deployment.yaml
@@ -119,8 +119,8 @@ spec:
         {{ toYaml .Values.global.extraContainers | nindent 8 }}
         {{- end }}
         securityContext: {{- toYaml .Values.temporalUi.podSecurityContext | nindent 8 }}
-        volumes:
         {{- if .Values.temporalUi.extraVolumes }}
+        volumes:
     {{ toYaml .Values.temporalUi.extraVolumes | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-webapp/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-webapp/deployment.yaml
@@ -142,11 +142,13 @@ spec:
       {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       securityContext: {{- toYaml .Values.webapp.podSecurityContext | nindent 8 }}
+      {{- if or .Values.webapp.extraVolumes .Values.global.extraVolumes }}
       volumes:
       {{- if .Values.webapp.extraVolumes }}
 {{ toYaml .Values.webapp.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if .Values.global.extraVolumes }}
 {{ toYaml .Values.global.extraVolumes | nindent 6 }}
+      {{- end }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
## What
`volumes:` label  in `spec.template.spec.containers` field throws the following warning if no `extraVolumes` are passed.
`warnings.go:70] unknown field "spec.template.spec.containers[0].volumes`

## How
Placing the `volumes:` label inside the if condition helps avoid the aforementioned warning when no `extraVolumes` are passed.

## Can this PR be safely reverted and rolled back?
- [x] YES :green_heart:
- [ ] NO :x: