### PR TITLE
🐛 Fix Helm Charts: remove leaking database credentials from airbyte's config map

### DIFF
--- a/charts/airbyte/templates/_database.tpl
+++ b/charts/airbyte/templates/_database.tpl
@@ -225,10 +225,4 @@ DATABASE_HOST: {{ include "airbyte.database.host" . }}
 DATABASE_PORT: {{ include "airbyte.database.port" . | quote }}
 DATABASE_DB: {{ include "airbyte.database.name" . }}
 DATABASE_URL: {{ include "airbyte.database.url" . }}
-{{- if .Values.global.database.user }}
-DATABASE_USER: {{ include "airbyte.database.user" . }}
-{{- end}}
-{{- if .Values.global.database.password }}
-DATABASE_PASSWORD: {{ include "airbyte.database.password" . }}
-{{- end}}
 {{- end }}


### PR DESCRIPTION
## What
The `airbyte_env` config map in `airbyte` charts includes database credentials, which should be a secret instead.

## How
Remove the credentials from the `airbyte_env` config map since these secrets are not referred to anywhere through this config map.

## Can this PR be safely reverted and rolled back?
- [x] YES :green_heart:
- [ ] NO :x: