### PR TITLE
🐛 Fix Helm Charts: include missing global.logging.level in airbyte values

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -10,6 +10,9 @@ global:
 
   airbyteYml: ""
 
+  logging:
+    level: "info"
+
   enterprise:
     # -- Secret name where an Airbyte license key is stored
     secretName: "airbyte-config-secrets"

--- a/charts/airbyte/values.yaml.test
+++ b/charts/airbyte/values.yaml.test
@@ -11,6 +11,9 @@ global:
   image:
     tag: dev
 
+  logging:
+    level: "info"
+
   env_vars: {}
   ##  database [object] -- Object used to override database configuration(to use external DB)
   ##  database.secretName -- secret name where DB creds are stored


### PR DESCRIPTION
## What
`airbyte` helm charts provide an option to change the log level, but the option is missing in the default values provided with the charts.

## How
Include `global.logging.level` in the `values.yaml` file.

## Recommended reading order
1. `values.yaml`
2. `values.yaml.test`

## Can this PR be safely reverted and rolled back?
- [x] YES :green_heart:
- [ ] NO :x: