### PR TITLE
🐛 Fix Helm Charts: add a storage class name for Min IO

### DIFF
--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -22,6 +22,9 @@ spec:
           resources:
             requests:
               storage: {{ .Values.minio.storage.volumeClaimValue  }}
+          {{- if .Values.minio.storage.storageClass }}
+          storageClassName: {{ .Values.minio.storage.storageClass }}
+          {{- end }}
   template:
     metadata:
       labels:

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1612,6 +1612,7 @@ minio:
     tag: RELEASE.2023-11-20T22-40-07Z
 
   storage:
+    storageClass: ~  # Add the storage class name here
     volumeClaimValue: 500Mi
 
   # -- Node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/

--- a/charts/airbyte/values.yaml.test
+++ b/charts/airbyte/values.yaml.test
@@ -1270,6 +1270,7 @@ minio:
     rootUser: minio
     rootPassword: minio123
   storage:
+    storageClass: standard
     volumeClaimValue: 500Mi
 
 cron:


### PR DESCRIPTION
## What
Adding a storage class label in helm charts for airbyte with Min IO because without no storage class name & no default set, it throws this error.
`no persistent volumes available for this claim and no storage class is set`

## How
A section has been added in the minio.yaml file in the airbyte templates where the storageClassName would be set only if a value has been passed.

## Recommended reading order
1. `minio.yaml`
2. `values.yaml`

## Can this PR be safely reverted and rolled back?
- [x] YES :green_heart:
- [ ] NO :x: