### PR TITLE
fix: adjusting temporal parameters structure to match the expected in code

### DIFF
--- a/airbyte-connector-rollout-client/src/main/resources/application.yml
+++ b/airbyte-connector-rollout-client/src/main/resources/application.yml
@@ -44,8 +44,9 @@ temporal:
       cert: ${TEMPORAL_CLOUD_CLIENT_CERT:}
       key: ${TEMPORAL_CLOUD_CLIENT_KEY:}
     enabled: ${TEMPORAL_CLOUD_ENABLED:false}
-    host: ${TEMPORAL_CLOUD_HOST:}
-    namespace: ${TEMPORAL_CLOUD_NAMESPACE:}
+    connector-rollout:
+      host: ${TEMPORAL_CLOUD_HOST:}
+      namespace: ${TEMPORAL_CLOUD_NAMESPACE:}
   host: ${TEMPORAL_HOST:`localhost:7233`}
   retention: ${TEMPORAL_HISTORY_RETENTION_IN_DAYS:30}
   sdk:


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->
airbyte-connector-rollout-client: the temporal parameters in application yaml are in a different structure than the expected in code: https://github.com/airbytehq/airbyte-platform/blob/abc6740f43a161ab23c6f12edd5dc5c07fc0f5fe/airbyte-connector-rollout-client/src/main/kotlin/io/airbyte/connector/rollout/client/ConnectorRolloutTemporalWorkflowServiceFactory.kt#L24-L25

## How
<!--
* Describe how code changes achieve the solution.
-->
this PR adjusts the application.yaml to be equal as the expected in the ConnectorRolloutTemporalWorkflowServiceFactory.kt file

## Recommended reading order
1. `airbyte-connector-rollout-client/src/main/kotlin/io/airbyte/connector/rollout/client/ConnectorRolloutTemporalWorkflowServiceFactory.kt`
2. `airbyte-connector-rollout-client/src/main/resources/application.yml`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
