### PR TITLE
Update link to docs

### DIFF
--- a/airbyte-webapp/src/core/utils/links.ts
+++ b/airbyte-webapp/src/core/utils/links.ts
@@ -56,7 +56,7 @@ export const links = {
   connectorSpecificationDocs: `${BASE_DOCS_LINK}/connector-development/connector-specification-reference/#airbyte-modifications-to-jsonschema`,
   schemaChangeManagement: `${BASE_DOCS_LINK}/using-airbyte/schema-change-management`,
   apiAccess: `${BASE_DOCS_LINK}/using-airbyte/configuring-api-access`,
-  deployingViaHttp: `${BASE_DOCS_LINK}/using-airbyte/getting-started/oss-quickstart#running-over-http`,
+  deployingViaHttp: `${BASE_DOCS_LINK}/platform/deploying-airbyte/abctl-ec2#running-over-http`,
   ossAuthentication: `${BASE_DOCS_LINK}/deploying-airbyte/integrations/authentication`,
   featureTalkToSales:
     "https://airbyte.com/company/talk-to-sales?utm_source=airbyte&utm_medium=product&utm_content=feature-{feature}",


### PR DESCRIPTION
## What

Section "Running over HTTP" was extracted to a different page in https://github.com/airbytehq/airbyte/commit/643e744facfcedc5868b7615fcdb9ab0bbb92f47

## How

Updated the link to docs.

## Recommended reading order
1. `airbyte-webapp/src/core/utils/links.ts`

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
