### PR TITLE
feat (helm charts): allow OIDC DisplayName to be customised

### DIFF
--- a/airbyte-keycloak-setup/src/main/java/io/airbyte/keycloak/setup/IdentityProvidersConfigurator.java
+++ b/airbyte-keycloak-setup/src/main/java/io/airbyte/keycloak/setup/IdentityProvidersConfigurator.java
@@ -105,9 +105,26 @@ public class IdentityProvidersConfigurator {
   private void updateExistingIdp(final RealmResource keycloakRealm,
                                  final IdentityProviderRepresentation existingIdp,
                                  final IdentityProviderRepresentation updatedIdp) {
+    log.debug("Before update - Existing IDP fields:");
+    log.debug("InternalId: {}", existingIdp.getInternalId());
+    log.debug("Alias: {}", existingIdp.getAlias());
+    log.debug("ProviderId: {}", existingIdp.getProviderId());
+    log.debug("Enabled: {}", existingIdp.isEnabled());
+    log.debug("DisplayName: {}", existingIdp.getDisplayName());
+    log.debug("Config: {}", existingIdp.getConfig());
+
     // In order to apply the updated IDP configuration to the existing IDP within Keycloak, we need to
     // set the internal ID of the existing IDP.
     updatedIdp.setInternalId(existingIdp.getInternalId());
+
+    log.debug("After update - Updated IDP fields:");
+    log.debug("InternalId: {}", updatedIdp.getInternalId());
+    log.debug("Alias: {}", updatedIdp.getAlias());
+    log.debug("ProviderId: {}", updatedIdp.getProviderId());
+    log.debug("Enabled: {}", updatedIdp.isEnabled());
+    log.debug("DisplayName: {}", updatedIdp.getDisplayName());
+    log.debug("Config: {}", updatedIdp.getConfig());
+
     keycloakRealm.identityProviders().get(existingIdp.getAlias()).update(updatedIdp);
   }
 

--- a/airbyte-keycloak-setup/src/main/resources/application.yml
+++ b/airbyte-keycloak-setup/src/main/resources/application.yml
@@ -25,6 +25,7 @@ airbyte:
       oidc:
         domain: ${OIDC_DOMAIN:}
         app-name: ${OIDC_APP_NAME:}
+        display-name: ${OIDC_DISPLAY_NAME:}
         client-id: ${OIDC_CLIENT_ID:}
         client-secret: ${OIDC_CLIENT_SECRET:}
     initial-user:

--- a/airbyte-keycloak-setup/src/main/resources/application.yml
+++ b/airbyte-keycloak-setup/src/main/resources/application.yml
@@ -54,5 +54,6 @@ logger:
     io.fabric8.kubernetes.client: INFO
     io.netty: INFO
     io.temporal: INFO
+    io.airbyte.keycloak: ${LOG_LEVEL:INFO}
 #   Uncomment to help resolve issues with conditional beans
 #      io.micronaut.context.condition: DEBUG

--- a/charts/airbyte/templates/_enterprise.tpl
+++ b/charts/airbyte/templates/_enterprise.tpl
@@ -69,6 +69,11 @@ Enteprise Configuration
     configMapKeyRef: 
       name: {{ .Release.Name }}-airbyte-env
       key: OIDC_APP_NAME
+- name: OIDC_DISPLAY_NAME
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Release.Name }}-airbyte-env
+      key: OIDC_DISPLAY_NAME
 - name: OIDC_CLIENT_ID
   valueFrom:
     secretKeyRef: 

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -43,6 +43,7 @@ data:
   IDENTITY_PROVIDER_TYPE: {{ .Values.global.auth.identityProvider.type }}
   OIDC_DOMAIN: {{ .Values.global.auth.identityProvider.oidc.domain }}
   OIDC_APP_NAME: {{ .Values.global.auth.identityProvider.oidc.appName }}
+  OIDC_DISPLAY_NAME: {{ .Values.global.auth.identityProvider.oidc.displayName | default .Values.global.auth.identityProvider.oidc.appName }}
     {{- end }}
   KEYCLOAK_INTERNAL_HOST: {{ .Release.Name }}-airbyte-keycloak-svc:{{ .Values.keycloak.service.port }}
   KEYCLOAK_PORT: {{ .Values.keycloak.service.port | quote }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -59,6 +59,8 @@ global:
     #    domain: ""
     #    # -- OIDC application name
     #    appName: ""
+    #    # -- OIDC application display name (sets the name to present to the user on the login form, defaults to appName if not set)  
+    #    displayName: ""
     #    # -- The key within `clientIdSecretName` where the OIDC client id is stored
     #    clientIdSecretKey: "client-id"
     #    # -- The key within `clientSecretSecretName` where the OIDC client secret is stored


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->
This PR solves https://github.com/airbytehq/oncall/issues/7823 by allowing users to define a DisplayName to be used for OIDC Provider definitions configured via the airbyte helm charts.


## How
<!--
* Describe how code changes achieve the solution.
-->
1. **Helm values.yaml**: Added `displayName` field with fallback to `appName`
2. **ConfigMap template**: Maps `displayName` to `OIDC_DISPLAY_NAME` environment variable
3. **Application config**: Maps environment variable to `airbyte.auth.identity-provider.oidc.display-name` property
4. **Code injection**: Uses `@Value` annotation to inject the display name into the OIDC configuration
5. **Keycloak setup**: Sets the display name on the identity provider via `idp.setDisplayName()`
## Recommended reading order
1. `charts/airbyte/values.yaml` - Added example of setting the displayName field
2. `charts/airbyte/templates/env-configmap.yaml` - Environment variable mapping
3. `airbyte-keycloak-setup/src/main/resources/application.yml` - sets Property mapping for displayname, and makes the log level configurable via env var.
4. [https://github.com/airbytehq/airbyte-platform/blob/f75fd45dfe3c6c39aa118cb8c980d2a549f51c80/airbyte-commons-auth/src/main/kotlin/io/airbyte/commons/auth/config/OidcConfigFactory.kt#L25](url) - This function handles value injection (no changes here, but listed for the full picture of what's happening.)
5. `airbyte-keycloak-setup/src/main/java/io/airbyte/keycloak/setup/IdentityProvidersConfigurator.java` - takes advantage of the log level improvement in "3" to allow easy inspection of updates to provider definitions when log level is set to DEBUG.

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [X] YES 💚
- [ ] NO ❌
