### PR TITLE
fix(helm-charts): node affinity and tolerations to the job

### DIFF
--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -182,4 +182,12 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-airbyte-env
               key: MINIO_ENDPOINT
+  {{- with .Values.minio.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.minio.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## What

Added node affinity and tolerations to the minio-create-bucket job

Without it, it's not possible to run such a job in clusters where nodeAffinity or tolerations are required to choose the node to run on.

```
admission webhook "validate.kyverno.affinity-check" denied the request: resource Pod/airbyte/airbyte-minio-create-bucket was blocked due to the following policies require-node-selector: check-for-nodeselector-pods: 'validation error: Pods must specify a nodeSelector. Please add a nodeSelector to your Pod specification. For pods in namespaces with a team label, use ''team: [namespace team]'' as your nodeSelector. This prevents your Pod from being scheduled on inappropriate nodes and ensures proper resource isolation. For help, see: ** or contact **. rule check-for-nodeselector-pods failed at path /spec/nodeSelector/' validate-team-node-assignment: validate-pod-team-match: 'validation error: Pod rejected: Team mismatch. Pods must be scheduled on nodes with matching team label as the namespace (team: grsi). For help, see: ** or contact **. rule validate-pod-team-match failed at path /spec/nodeSelector/'
```

## How

Add nodeSelector and tolerations to the "create-bucket" job with the same content as minio itself has.

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
