### PR TITLE
chore: Remove errant Workspace#list entity operation

### DIFF
--- a/airbyte-api/server-api/src/main/openapi/api.yaml
+++ b/airbyte-api/server-api/src/main/openapi/api.yaml
@@ -2089,7 +2089,6 @@ paths:
       x-speakeasy-alias: listWorkspaces
       x-speakeasy-group: Workspaces
       summary: List workspaces
-      x-speakeasy-entity-operation: Workspace#list
       parameters:
       - name: workspaceIds
         description: The UUIDs of the workspaces you wish to fetch. Empty list will

--- a/airbyte-api/server-api/src/main/openapi/api_documentation_workspaces.yaml
+++ b/airbyte-api/server-api/src/main/openapi/api_documentation_workspaces.yaml
@@ -29,7 +29,6 @@ paths:
       x-speakeasy-alias: "listWorkspaces"
       x-speakeasy-group: "Workspaces"
       summary: "List workspaces"
-      x-speakeasy-entity-operation: "Workspace#list"
       parameters:
       - name: "workspaceIds"
         description: "The UUIDs of the workspaces you wish to fetch. Empty list will\

--- a/airbyte-api/server-api/src/main/openapi/api_sdk.yaml
+++ b/airbyte-api/server-api/src/main/openapi/api_sdk.yaml
@@ -1444,7 +1444,6 @@ paths:
       x-speakeasy-alias: "listWorkspaces"
       x-speakeasy-group: "Workspaces"
       summary: "List workspaces"
-      x-speakeasy-entity-operation: "Workspace#list"
       parameters:
       - name: "workspaceIds"
         description: "The UUIDs of the workspaces you wish to fetch. Empty list will\

--- a/airbyte-api/server-api/src/main/openapi/config.yaml
+++ b/airbyte-api/server-api/src/main/openapi/config.yaml
@@ -9110,7 +9110,6 @@ paths:
       x-sdk-alias: listWorkspaces
       x-sdk-group: Workspaces
       summary: List workspaces
-      x-sdk-entity-operation: Workspace#list
       parameters:
         - name: workspaceIds
           description: The UUIDs of the workspaces you wish to fetch. Empty list will retrieve all allowed workspaces.

--- a/airbyte-api/server-api/src/main/openapi/public_api.yaml
+++ b/airbyte-api/server-api/src/main/openapi/public_api.yaml
@@ -467,7 +467,6 @@ paths:
       x-sdk-alias: listWorkspaces
       x-sdk-group: Workspaces
       summary: List workspaces
-      x-sdk-entity-operation: Workspace#list
       parameters:
         - name: workspaceIds
           description: The UUIDs of the workspaces you wish to fetch. Empty list will retrieve all allowed workspaces.


### PR DESCRIPTION
## What

The expected entity operations for downstream tooling are one of `create`, `read`, `update`, and `delete`:

```
Error: Unexpected op annotation list applied as Workspace#list: expected it to be one of ["create","read","update","delete"]
```

Since the `listWorkspaces` API operation appears to be intended as its own Terraform data resource and its usage would be separate from the workspace managed resource, the entity operation could be updated to create a workspaces data resource via `Workspaces#read`. However, it is removed for now to match the current behavior of not doing anything in the Terraform code generation while also preventing the error.

## How

Removed various `x-sdk-entity-operation: Workspace#list` and `x-speakeasy-entity-operation: Workspace#list` usage in OpenAPI Specification documents.

## Recommended reading order
1. `x.kt`
2. `y.kt`

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [ ] YES 💚
- [ ] NO ❌
