### PR TITLE
fix(helm-charts): test-webapp allow the use of redirect in args

### DIFF
--- a/charts/airbyte/templates/tests/test-webapp.yaml
+++ b/charts/airbyte/templates/tests/test-webapp.yaml
@@ -17,8 +17,8 @@ spec:
   containers:
   - name: webapp-test
     image: {{ include "imageUrl" (list .Values.testWebapp.image $) }}
-    command: ['curl']
-    args: ['-s', '{{ .Release.Name }}-airbyte-webapp-svc:{{ .Values.webapp.service.port }}', '>', '/dev/null']
+    command: ['/bin/sh', '-c']
+    args: ['curl -s {{ .Release.Name }}-airbyte-webapp-svc:{{ .Values.webapp.service.port }} > /dev/null']
     resources:
       requests:
         memory: "64Mi"

--- a/charts/v2/airbyte/templates/tests/test-webapp.yaml
+++ b/charts/v2/airbyte/templates/tests/test-webapp.yaml
@@ -17,8 +17,8 @@ spec:
   containers:
   - name: webapp-test
     image: {{ include "imageUrl" (list .Values.testWebapp.image $) }}
-    command: ['curl']
-    args: ['-s', '{{ .Release.Name }}-airbyte-webapp-svc:{{ .Values.webapp.service.port }}', '>', '/dev/null']
+    command: ['/bin/sh', '-c']
+    args: ['curl -s {{ .Release.Name }}-airbyte-webapp-svc:{{ .Values.webapp.service.port }} > /dev/null']
     resources:
       requests:
         memory: "64Mi"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->
The `test-webapp.yaml` pod always exit in an error code 3 due to curl.

It seems that the redirect `>` in the args parameter is not well handle, as the pod show curl logs:
```
$ kubectl logs -f airbyte-test-connection
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <link rel="icon" href="/favicon.ico">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="theme-color" content="#000000">
    <meta
      name="description"
      content="Airbyte is the turnkey open-source data integration platform that syncs data from applications, APIs and databases to warehouses."
    >
```

The proper formatted command executed inside the pod show nothing as it should be:
```
$ k exec -it airbyte-test-connection -- sh
sh-4.2$ 
sh-4.2$ curl -s airbyte-airbyte-webapp-svc:80 > /dev/null
sh-4.2$ exit
```
## How
<!--
* Describe how code changes achieve the solution.
-->
By using the Kubernetes way to run a command in a shell:
https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#run-a-command-in-a-shell

We allow the use of the redirect `> /dev/null`

## Recommended reading order
N/A

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [X] YES 💚
- [ ] NO ❌
