### PR TITLE
fix: use local storage for enterprise auth

### DIFF
--- a/airbyte-webapp/src/core/services/auth/EnterpriseAuthService.tsx
+++ b/airbyte-webapp/src/core/services/auth/EnterpriseAuthService.tsx
@@ -1,3 +1,4 @@
+import { WebStorageStateStore } from "oidc-client-ts";
 import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { AuthProvider, useAuth } from "react-oidc-context";
@@ -39,6 +40,8 @@ export const EnterpriseAuthService: React.FC<PropsWithChildren<unknown>> = ({ ch
         : window.location.pathname;
       window.history.replaceState({}, document.title, newUrl);
     },
+    // Use local storage to persist tokens across sessions
+    userStore: new WebStorageStateStore({ store: window.localStorage }),
   };
 
   return (


### PR DESCRIPTION
## What
Persist the Enterprise webapp login state within the browser to avoid reauthenticating in new sessions. Links that open a new tab or window will otherwise re-initiate the login flow and redirect to the workspace landing page. 

This addresses https://github.com/airbytehq/airbyte/issues/63355, but note that the redirect issue still may arise upon "initial" user login, after which navigation is expected to behave correctly. So there still may be an opportunity to improve redirect behavior within the webapp, but this is outside of my expertise.

## How
Add a `WebStorageStateStore` to the `react-oidc-context` configuration that uses local browser storage for the ID and access tokens.

## Recommended reading order
1. `EnterpriseAuthService.tsx`

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
