### PR TITLE
fix (airbyte-temporal dockerfile): formulate entrypoint as array

### DIFF
--- a/airbyte-temporal/Dockerfile
+++ b/airbyte-temporal/Dockerfile
@@ -3,4 +3,4 @@ FROM temporalio/auto-setup:1.27.2
 
 ENV TEMPORAL_HOME /etc/temporal
 
-ENTRYPOINT ["./entrypoint.sh autosetup"]
+ENTRYPOINT ["./entrypoint.sh", "autosetup"]


### PR DESCRIPTION
## What
Local builds were failing due to an entry point issue.

## How
Make docker entrypoint to array

## Recommended reading order
N/A - just a simple dockerfile fix


## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [ ] YES 💚
- [ ] NO ❌
