### PR TITLE
Pin GitHub Actions to SHA1 for supply chain security

### DIFF
--- a/.github/actions/cache-build-artifacts/action.yml
+++ b/.github/actions/cache-build-artifacts/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Pip Caching
       if: ${{ inputs.cache_python }} == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/pip
@@ -23,7 +23,7 @@ runs:
           ${{ inputs.cache-key }}-pip-${{ runner.os }}-
 
     - name: Npm Caching
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.npm
@@ -32,7 +32,7 @@ runs:
           ${{ inputs.cache-key }}-npm-${{ runner.os }}-
 
     - name: pnpm Caching
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.local/share/pnpm/store
@@ -44,7 +44,7 @@ runs:
     # gradle caching is handled by the gradle/actions/setup-gradle action
     # see https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
     - name: Python Caching
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           **/.venv

--- a/.github/actions/runner-prepare-for-build/action.yml
+++ b/.github/actions/runner-prepare-for-build/action.yml
@@ -17,21 +17,21 @@ runs:
   using: "composite"
   steps:
     - if: inputs.install_java == 'true'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: corretto
         java-version: 21
 
     - if: inputs.install_java == 'true'
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
     - if: inputs.install_node == 'true'
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: "lts/*"
 
     - if: inputs.install_python == 'true'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
       with:
         python-version: "3.9"
 

--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
@@ -54,7 +54,7 @@ runs:
 
     - name: Start EC2 runner
       id: start-ec2-runner
-      uses: airbytehq/ec2-github-runner@MSGv0.0.5
+      uses: airbytehq/ec2-github-runner@b671ff1f194623671b398d973a8965348391831d # MSGv0.0.5
       with:
         mode: start
         github-token: ${{ inputs.github-token }}

--- a/.github/workflows/create-cloud-pr-command.yml
+++ b/.github/workflows/create-cloud-pr-command.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Create branch snapshot
         id: create-branch-snapshot

--- a/.github/workflows/create-oss-pr-snapshot-in-cloud.yml
+++ b/.github/workflows/create-oss-pr-snapshot-in-cloud.yml
@@ -16,14 +16,14 @@ jobs:
         - id: get-branch-and-repo
           run: |
             echo "repo_full_name=$(curl ${{ github.event.issue.pull_request.url }} | jq --raw-output .head.repo.full_name)" >> $GITHUB_OUTPUT
-        - uses: xt0rted/pull-request-comment-branch@v1
+        - uses: xt0rted/pull-request-comment-branch@653a7d5ca8bd91d3c5cb83286063314d0b063b8e # v1.4.0
           id: comment-branch
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
           with:
             repository: ${{ steps.get-branch-and-repo.outputs.repo_full_name }}
             ref: ${{ steps.comment-branch.outputs.head_ref }}
             fetch-depth: 0 # needed to have the base branch available for the action below
-        - uses: stefanluptak/check-branch-up-to-date@v1
+        - uses: stefanluptak/check-branch-up-to-date@8b8b07b76e80b6f5f51b98d360844a9ca9c60b5b # v1
           id: branch-up-to-date
           with:
             base_branch: 'main'
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Create a snapshot of an OSS PR to Cloud
         if: needs.check.outputs.branch_up_to_date == 'true'
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@f996d7b7aae9059759ac55e978cff76d91853301 # v3.0.2
         id: slash-command-dispatch
         with:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Publish comment with requirements to update branch
         if: needs.check.outputs.branch_up_to_date == 'false'
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -60,7 +60,7 @@ jobs:
 
       - name: Publish comment with error message
         if: steps.slash-command-dispatch.outputs.error-message
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
         with:
           comment-id: ${{ github.event.comment.id }}
           body: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Check images exist
         run: ./tools/bin/check_images_exist.sh all
@@ -55,8 +55,8 @@ jobs:
       frontendServers: ${{ steps.changes.outputs.frontendServers }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:
           # Note, the following glob expression within a filters are ORs.
@@ -107,26 +107,26 @@ jobs:
       || (always() && needs.changes.outputs.frontendServers == 'true')
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
         with:
           cache-key: ${{ secrets.CACHE_VERSION }}
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: corretto
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "lts/*"
 
       - name: Format
-        uses: Wandalen/wretry.action@v1.0.36
+        uses: Wandalen/wretry.action@e6cf3db7de3777ba5f999f903c2f4efdd9ac7288 # v1.0.36
         with:
           command: ./gradlew format --scan --info --stacktrace
           attempt_limit: 3
@@ -136,7 +136,7 @@ jobs:
         run: git --no-pager diff && test -z "$(git --no-pager diff)"
 
       - name: Build
-        uses: Wandalen/wretry.action@v1.0.36
+        uses: Wandalen/wretry.action@e6cf3db7de3777ba5f999f903c2f4efdd9ac7288 # v1.0.36
         with:
           # todo (cgardens): temporarily skipping airbyte-commons-worker because one of the tests uses too much memory. we are
           # adjusting the test to use a more reasonable amount of memory. https://github.com/airbytehq/oncall/issues/4415
@@ -161,7 +161,7 @@ jobs:
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Match GitHub User to Slack User
         id: match-github-to-slack-user
         uses: ./.github/actions/match-github-to-slack-user
@@ -169,7 +169,7 @@ jobs:
           AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to OSS Build Failure Slack Channel
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
@@ -204,14 +204,14 @@ jobs:
     if: ${{ success() && github.ref == 'refs/heads/main' }}
     steps:
       - name: Get Previous Workflow Status
-        uses: Mercymeilya/last-workflow-status@v0.3
+        uses: Mercymeilya/last-workflow-status@040f64adf6b3514a99a3ce92c48cef9c5aea6caf # v0.3
         id: last_status
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       # To avoid clogging up the channel, only publish build success if the previous build was a failure since this means the build was fixed.
       - name: Publish Build Fixed Message to OSS Build Failure Slack Channel
         if: ${{ steps.last_status.outputs.last_status == 'failure' }}
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}

--- a/.github/workflows/label-pr-by-filepath.yml
+++ b/.github/workflows/label-pr-by-filepath.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Label PR based on changed files"
-        uses: actions/labeler@v3
+        uses: actions/labeler@3d612d72e6784a1a65365cc6d33b5a001c12bf10 # v3.1.0
         with:
           repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           sync-labels: true

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Issue Command from workflow-actions
-        uses: nick-fields/private-action-loader@v3
+        uses: nick-fields/private-action-loader@6fa713597d3de3707f8b7a3029a5c262f32c5bca # v3.0.12
         with:
           pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           pal-repo-name: airbytehq/workflow-actions@production

--- a/.github/workflows/terminate-zombie-build-instances.yml
+++ b/.github/workflows/terminate-zombie-build-instances.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: List and Terminate GH actions in status 'offline'
         env:
           GITHUB_PAT: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}


### PR DESCRIPTION
## What
- Pin all GitHub Actions to their specific SHA1 hashes to reduce supply chain attack risk
- Replaces version tags with specific commit SHAs
- Includes version comments for easier reference

See internal wiki page on supply chain security for further info

## How
Used the tool Pinact to pin the SHA for GitHub Actions. 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
No impact

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌