### PR TITLE
feat(helm): optional traffic policy fields and annotation parity for chart v2 Services

### DIFF
--- a/charts/v2/airbyte/templates/airbyte-featureflag-server/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-featureflag-server/service.yaml
@@ -12,11 +12,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.featureflagServer.service.type }}
+  {{- with .Values.featureflagServer.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.featureflagServer.service.externalTrafficPolicy (or (eq .Values.featureflagServer.service.type "NodePort") (eq .Values.featureflagServer.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.featureflagServer.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.featureflagServer.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.featureflagServer.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.featureflagServer.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "airbyte.selectorLabels" . | nindent 4 }}
     {{- if .Values.featureflagServer.extraSelectorLabels }}

--- a/charts/v2/airbyte/templates/airbyte-keycloak/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-keycloak/service.yaml
@@ -14,11 +14,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.keycloak.service.type }}
+  {{- with .Values.keycloak.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.keycloak.service.externalTrafficPolicy (or (eq .Values.keycloak.service.type "NodePort") (eq .Values.keycloak.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.keycloak.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.keycloak.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.keycloak.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.keycloak.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
       {{ if and (eq .Values.keycloak.service.type "NodePort") (.Values.keycloak.service.nodePort)  }}
       nodePort: {{ .Values.keycloak.service.nodePort }}
       {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-manifest-server/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-manifest-server/service.yaml
@@ -13,11 +13,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.manifestServer.service.type }}
+  {{- with .Values.manifestServer.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.manifestServer.service.externalTrafficPolicy (or (eq .Values.manifestServer.service.type "NodePort") (eq .Values.manifestServer.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.manifestServer.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.manifestServer.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.manifestServer.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.manifestServer.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "airbyte.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-server/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-server/service.yaml
@@ -13,11 +13,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.server.service.type }}
+  {{- with .Values.server.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.server.service.externalTrafficPolicy (or (eq .Values.server.service.type "NodePort") (eq .Values.server.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.server.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.server.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
   - port: {{ .Values.server.service.port }}
     targetPort: http
     protocol: TCP
     name: http
+    {{- with .Values.server.service.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
     {{- if and (or (eq .Values.server.service.type "NodePort") (eq .Values.server.service.type "LoadBalancer")) .Values.server.service.nodePort }}
     nodePort: {{ .Values.server.service.nodePort }}
     {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-stigg-sidecar/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-stigg-sidecar/service.yaml
@@ -5,14 +5,30 @@ kind: Service
 metadata:
   namespace: {{ include "airbyte.namespace" . }}
   name: {{ .Release.Name }}-stigg-sidecar-svc
+  {{- with .Values.stiggSidecar.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.stiggSidecar.service.type }}
+  {{- with .Values.stiggSidecar.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.stiggSidecar.service.externalTrafficPolicy (or (eq .Values.stiggSidecar.service.type "NodePort") (eq .Values.stiggSidecar.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.stiggSidecar.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.stiggSidecar.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
   - port: {{ .Values.stiggSidecar.service.port }}
     protocol: TCP
     targetPort: 8800
+    {{- with .Values.stiggSidecar.service.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   selector:
     {{- include "airbyte.selectorLabels" . | nindent 4 }}
     {{- if .Values.stiggSidecar.extraSelectorLabels }}

--- a/charts/v2/airbyte/templates/airbyte-temporal-ui/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-temporal-ui/service.yaml
@@ -13,11 +13,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.temporalUi.service.type }}
+  {{- with .Values.temporalUi.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.temporalUi.service.externalTrafficPolicy (or (eq .Values.temporalUi.service.type "NodePort") (eq .Values.temporalUi.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.temporalUi.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.temporalUi.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.temporalUi.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.temporalUi.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "airbyte.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-temporal/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-temporal/service.yaml
@@ -5,14 +5,30 @@ kind: Service
 metadata:
   namespace: {{ include "airbyte.namespace" . }}
   name: {{ .Release.Name }}-temporal
+  {{- with .Values.temporal.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.temporal.service.type }}
+  {{- with .Values.temporal.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.temporal.service.externalTrafficPolicy (or (eq .Values.temporal.service.type "NodePort") (eq .Values.temporal.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.temporal.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.temporal.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
   - port: {{ .Values.temporal.service.port }}
     protocol: TCP
     targetPort: 7233
+    {{- with .Values.temporal.service.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   selector:
     {{- include "airbyte.selectorLabels" . | nindent 4 }}
     {{- if .Values.temporal.extraSelectorLabels }}

--- a/charts/v2/airbyte/templates/airbyte-webapp/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-webapp/service.yaml
@@ -13,11 +13,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.webapp.service.type }}
+  {{- with .Values.webapp.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.webapp.service.externalTrafficPolicy (or (eq .Values.webapp.service.type "NodePort") (eq .Values.webapp.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.webapp.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.webapp.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
   - port: {{ .Values.webapp.service.port }}
     targetPort: http
     protocol: TCP
     name: http
+    {{- with .Values.webapp.service.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
     {{ if and (eq .Values.webapp.service.type "NodePort") (.Values.webapp.service.nodePort)  }}
     nodePort: {{ .Values.webapp.service.nodePort }}
     {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-workload-api-server/service.yaml
+++ b/charts/v2/airbyte/templates/airbyte-workload-api-server/service.yaml
@@ -12,11 +12,23 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.workloadApiServer.service.type }}
+  {{- with .Values.workloadApiServer.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- if and .Values.workloadApiServer.service.externalTrafficPolicy (or (eq .Values.workloadApiServer.service.type "NodePort") (eq .Values.workloadApiServer.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.workloadApiServer.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.workloadApiServer.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.workloadApiServer.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.workloadApiServer.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "airbyte.selectorLabels" . | nindent 4 }}
     {{- if .Values.workloadApiServer.extraSelectorLabels }}

--- a/charts/v2/airbyte/values.yaml
+++ b/charts/v2/airbyte/values.yaml
@@ -626,6 +626,14 @@ webapp:
     port: 80
     # -- Annotations for the webapp service resource
     annotations: {}
+    # -- Optional internalTrafficPolicy for the webapp service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the webapp service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the webapp service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the webapp service port
+    appProtocol: ""
 
   ## Web app resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -834,6 +842,14 @@ server:
     # -- Optional: specify a NodePort when type is NodePort or LoadBalancer
     nodePort: ""
     annotations: {}
+    # -- Optional internalTrafficPolicy for the server service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the server service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the server service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the server service port
+    appProtocol: ""
 
   annotations: {}
 
@@ -1837,6 +1853,16 @@ temporal:
     type: ClusterIP
     # -- The temporal port and exposed kubernetes port
     port: 7233
+    # -- Annotations for the temporal service resource
+    annotations: {}
+    # -- Optional internalTrafficPolicy for the temporal service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the temporal service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the temporal service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the temporal service port
+    appProtocol: ""
 
   prometheus:
     endpoint: ""
@@ -1972,6 +1998,14 @@ temporalUi:
     type: ClusterIP
     # -- The temporal-ui port and exposed kubernetes port
     port: 8088
+    # -- Optional internalTrafficPolicy for the temporal-ui service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the temporal-ui service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the temporal-ui service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the temporal-ui service port
+    appProtocol: ""
 
   # -- Add extra annotations to the temporal-ui pod
   podAnnotations: {}
@@ -2429,6 +2463,14 @@ keycloak:
     type: ClusterIP
     port: 8180
     annotations: {}
+    # -- Optional internalTrafficPolicy for the keycloak service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the keycloak service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the keycloak service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the keycloak service port
+    appProtocol: ""
 
   headlessService:
     annotations: {}
@@ -2665,6 +2707,14 @@ manifestServer:
     type: ClusterIP
     port: 8080
     annotations: {}
+    # -- Optional internalTrafficPolicy for the manifest-server service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the manifest-server service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the manifest-server service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the manifest-server service port
+    appProtocol: ""
 
   # -- Node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: { }
@@ -2804,6 +2854,14 @@ workloadApiServer:
     type: ClusterIP
     port: 8001
     annotations: {}
+    # -- Optional internalTrafficPolicy for the workload-api-server service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the workload-api-server service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the workload-api-server service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the workload-api-server service port
+    appProtocol: ""
 
   # Configure the ingress resource that allows you to access the Airbyte Workload API, see http://kubernetes.io/docs/user-guide/ingress/
   ingress:
@@ -2940,6 +2998,14 @@ featureflagServer:
   env_vars: {}
   service:
     port: 8007
+    # -- Optional internalTrafficPolicy for the featureflag-server service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the featureflag-server service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the featureflag-server service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the featureflag-server service port
+    appProtocol: ""
 
   # Configure the ingress resource that allows you to access the Airbyte Workload API, see http://kubernetes.io/docs/user-guide/ingress/
   ingress:
@@ -2993,6 +3059,14 @@ stiggSidecar:
     type: ClusterIP
     port: 8800
     annotations: {}
+    # -- Optional internalTrafficPolicy for the stigg-sidecar service (Cluster or Local)
+    internalTrafficPolicy: ""
+    # -- Optional externalTrafficPolicy for the stigg-sidecar service, only applied when type is NodePort or LoadBalancer
+    externalTrafficPolicy: ""
+    # -- Optional trafficDistribution for the stigg-sidecar service (for example PreferClose)
+    trafficDistribution: ""
+    # -- Optional appProtocol for the stigg-sidecar service port
+    appProtocol: ""
 
   annotations: {}
 


### PR DESCRIPTION
## What

Adds optional, values-driven fields to every Service template in charts/v2/airbyte:

* `internalTrafficPolicy` (Cluster or Local)
* `externalTrafficPolicy` (rendered only for NodePort or LoadBalancer Services, as the API requires)
* `trafficDistribution` (for example `PreferClose`, Kubernetes 1.30+)
* optional `appProtocol` on port entries
* an `annotations` block for the two Services that currently lack one (temporal, stigg-sidecar), bringing them to parity with the other seven

All fields are optional and gated with `with`/`if`. A chart rendered without them is byte-identical to today.

## Why

Self-managed deployments on multi-AZ clusters want zone-aware routing for in-cluster traffic to Airbyte's Services to reduce cross-AZ latency and data transfer cost. These are standard Kubernetes Service fields, but none of the nine Service templates currently accept them, so the only option is patching Services after `helm upgrade`, which leaves cluster state unmanaged by the chart.

## How

Follows the chart's existing conventions: guarded blocks in the templates, `# --` helm-docs annotations for every new key in values.yaml, defaults empty. No changes to autogenerated files under templates/config.
