### PR TITLE
feat(helm): per-component priorityClassName and update strategy; extend topologySpreadConstraints; remove unused hpa values

### DIFF
--- a/charts/v2/airbyte/templates/airbyte-bootloader/pod.yaml
+++ b/charts/v2/airbyte/templates/airbyte-bootloader/pod.yaml
@@ -36,6 +36,9 @@ spec:
   {{- if .Values.airbyteBootloader.affinity }}
   affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.airbyteBootloader.affinity "context" $) | nindent 4 }}
   {{- end }}
+  {{- with .Values.airbyteBootloader.priorityClassName }}
+  priorityClassName: {{ . }}
+  {{- end }}
   {{- if .Values.airbyteBootloader.extraInitContainers }}
   initContainers:
   {{- toYaml .Values.airbyteBootloader.extraInitContainers | nindent 4 }}

--- a/charts/v2/airbyte/templates/airbyte-connector-rollout-worker/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-connector-rollout-worker/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{ toYaml (mergeOverwrite .Values.connectorRolloutWorker.extraSelectorLabels .Values.global.extraSelectorLabels) | nindent 6 }}
       {{- end }}
   strategy:
-    type: Recreate
+    type: {{ .Values.connectorRolloutWorker.deploymentStrategyType }}
   template:
     metadata:
       labels:
@@ -52,6 +52,9 @@ spec:
       {{- end }}
       {{- if .Values.connectorRolloutWorker.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.connectorRolloutWorker.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.connectorRolloutWorker.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       {{- if .Values.connectorRolloutWorker.extraInitContainers }}
       initContainers:

--- a/charts/v2/airbyte/templates/airbyte-cron/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-cron/deployment.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.cron.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.cron.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.cron.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.cron.extraInitContainers }}
       initContainers:
       {{- toYaml .Values.cron.extraInitContainers | nindent 6 }}

--- a/charts/v2/airbyte/templates/airbyte-featureflag-server/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-featureflag-server/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       {{ toYaml (mergeOverwrite .Values.featureflagServer.extraSelectorLabels .Values.global.extraSelectorLabels) | nindent 6 }}
       {{- end }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.featureflagServer.deploymentStrategyType }}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 100%
@@ -52,6 +52,9 @@ spec:
       {{- end }}
       {{- if .Values.featureflagServer.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.featureflagServer.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.featureflagServer.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       {{- if .Values.featureflagServer.extraInitContainers }}
       initContainers:

--- a/charts/v2/airbyte/templates/airbyte-keycloak/statefulset.yaml
+++ b/charts/v2/airbyte/templates/airbyte-keycloak/statefulset.yaml
@@ -50,6 +50,9 @@ spec:
       {{- if .Values.keycloak.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.keycloak.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.keycloak.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.global.imagePullSecrets }}

--- a/charts/v2/airbyte/templates/airbyte-manifest-server/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-manifest-server/deployment.yaml
@@ -50,6 +50,9 @@ spec:
       {{- if .Values.manifestServer.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.manifestServer.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.manifestServer.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.manifestServer.extraInitContainers }}
       initContainers:
       {{- toYaml .Values.manifestServer.extraInitContainers | nindent 8 }}

--- a/charts/v2/airbyte/templates/airbyte-metrics/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-metrics/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       airbyte: metrics
   strategy:
-    type: Recreate # Needed due to volume claims
+    type: {{ .Values.metrics.deploymentStrategyType }} # Needed due to volume claims
   template:
     metadata:
       labels:
@@ -48,6 +48,9 @@ spec:
       {{- end }}
       {{- if .Values.metrics.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.metrics.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       containers:
       - name: airbyte-metrics-container

--- a/charts/v2/airbyte/templates/airbyte-server/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-server/deployment.yaml
@@ -54,6 +54,9 @@ spec:
       {{- if .Values.server.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.server.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.server.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "airbyte.tplvalues.render" (dict "value" .Values.server.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/v2/airbyte/templates/airbyte-stigg-sidecar/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-stigg-sidecar/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       {{ toYaml (mergeOverwrite .Values.stiggSidecar.extraSelectorLabels .Values.global.extraSelectorLabels) | nindent 6 }}
       {{- end }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.stiggSidecar.deploymentStrategyType }}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 100%
@@ -72,6 +72,9 @@ spec:
       {{- end }}
       {{- if .Values.stiggSidecar.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.stiggSidecar.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.stiggSidecar.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       {{- if .Values.stiggSidecar.extraInitContainers }}
       initContainers:

--- a/charts/v2/airbyte/templates/airbyte-temporal-ui/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-temporal-ui/deployment.yaml
@@ -46,6 +46,9 @@ spec:
       {{- if .Values.temporalUi.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.temporalUi.affinity "context" $) | nindent 6 }}
       {{- end }}
+      {{- with .Values.temporalUi.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.temporalUi.extraInitContainers }}
       initContainers:
       {{- toYaml .Values.temporalUi.extraInitContainers | nindent 6 }}

--- a/charts/v2/airbyte/templates/airbyte-temporal/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-temporal/deployment.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.temporal.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.temporal.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.temporal.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
 {{- if .Values.temporal.extraInitContainers }}
       initContainers:
 {{- toYaml .Values.temporal.extraInitContainers | nindent 6 }}

--- a/charts/v2/airbyte/templates/airbyte-webapp/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-webapp/deployment.yaml
@@ -45,6 +45,9 @@ spec:
       {{- if .Values.webapp.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.webapp.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.webapp.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.global.imagePullSecrets }}

--- a/charts/v2/airbyte/templates/airbyte-worker/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-worker/deployment.yaml
@@ -51,6 +51,12 @@ spec:
       {{- if .Values.worker.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.worker.affinity "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.worker.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- if .Values.worker.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "airbyte.tplvalues.render" (dict "value" .Values.worker.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.worker.extraInitContainers }}
       initContainers:
       {{- toYaml .Values.worker.extraInitContainers | nindent 6 }}

--- a/charts/v2/airbyte/templates/airbyte-workload-api-server/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-workload-api-server/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       {{ toYaml (mergeOverwrite .Values.workloadApiServer.extraSelectorLabels .Values.global.extraSelectorLabels) | nindent 6 }}
       {{- end }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.workloadApiServer.deploymentStrategyType }}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 100%
@@ -52,6 +52,12 @@ spec:
       {{- end }}
       {{- if .Values.workloadApiServer.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.workloadApiServer.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workloadApiServer.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- if .Values.workloadApiServer.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "airbyte.tplvalues.render" (dict "value" .Values.workloadApiServer.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.workloadApiServer.extraInitContainers }}
       initContainers:

--- a/charts/v2/airbyte/templates/airbyte-workload-launcher/deployment.yaml
+++ b/charts/v2/airbyte/templates/airbyte-workload-launcher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{ toYaml (mergeOverwrite .Values.workloadLauncher.extraSelectorLabels .Values.global.extraSelectorLabels) | nindent 6 }}
       {{- end }}
   strategy:
-    type: Recreate
+    type: {{ .Values.workloadLauncher.deploymentStrategyType }}
   template:
     metadata:
       labels:
@@ -52,6 +52,12 @@ spec:
       {{- end }}
       {{- if .Values.workloadLauncher.affinity }}
       affinity: {{- include "airbyte.tplvalues.render" (dict "value" .Values.workloadLauncher.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workloadLauncher.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- if .Values.workloadLauncher.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "airbyte.tplvalues.render" (dict "value" .Values.workloadLauncher.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.workloadLauncher.extraInitContainers }}
       initContainers:

--- a/charts/v2/airbyte/values.yaml
+++ b/charts/v2/airbyte/values.yaml
@@ -656,6 +656,8 @@ webapp:
   # -- Affinity and anti-affinity for webapp pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for webapp pods
+  priorityClassName: ""
 
   ## Configure the ingress resource that allows you to access the Airbyte installation.
   ## ref: http://kubernetes.io/docs/user-guide/ingress/
@@ -920,6 +922,8 @@ server:
   # -- Affinity and anti-affinity for server pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for server pods
+  priorityClassName: ""
 
   log:
     # -- The log level to log at
@@ -1125,6 +1129,10 @@ worker:
   # -- Affinity and anti-affinity for worker pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for worker pods
+  priorityClassName: ""
+  # -- Topology spread constraints for worker pods
+  topologySpreadConstraints: []
 
   log:
     #! -- The log level to log at.
@@ -1155,9 +1163,6 @@ worker:
   extraInitContainers: []
   extraContainers: []
 
-  hpa:
-    enabled: false
-
   debug:
     enabled: false
 
@@ -1183,6 +1188,8 @@ workloadLauncher:
   enabled: true
   # -- Number of workload launcher replicas
   replicaCount: 1
+  # -- Deployment update strategy type for workload-launcher (Recreate or RollingUpdate)
+  deploymentStrategyType: Recreate
 
   serviceAccountName:
 
@@ -1292,6 +1299,10 @@ workloadLauncher:
   # Affinity and anti-affinity for workload launcher pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for workload-launcher pods
+  priorityClassName: ""
+  # -- Topology spread constraints for workload-launcher pods
+  topologySpreadConstraints: []
 
   log:
     # -- The log level to log at
@@ -1321,9 +1332,6 @@ workloadLauncher:
 
   extraInitContainers: []
   extraContainers: []
-
-  hpa:
-    enabled: false
 
   debug:
     enabled: false
@@ -1369,6 +1377,8 @@ connectorRolloutWorker:
   enabled: false
   # -- Number of connector rollout worker replicas
   replicaCount: 1
+  # -- Deployment update strategy type for connector-rollout-worker (Recreate or RollingUpdate)
+  deploymentStrategyType: Recreate
 
   serviceAccountName:
 
@@ -1464,6 +1474,8 @@ connectorRolloutWorker:
   # Affinity and anti-affinity for connector rollout worker pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for connector-rollout-worker pods
+  priorityClassName: ""
 
   log:
     # -- The log level to log at
@@ -1496,9 +1508,6 @@ connectorRolloutWorker:
 
   env_vars: {}
 
-  hpa:
-    enabled: false
-
   debug:
     enabled: false
 
@@ -1526,6 +1535,8 @@ metrics:
 
   # -- Number of metrics-reporter replicas
   replicaCount: 1
+  # -- Deployment update strategy type for metrics (Recreate or RollingUpdate)
+  deploymentStrategyType: Recreate
 
   serviceAccountName:
 
@@ -1593,6 +1604,8 @@ metrics:
   # -- Affinity and anti-affinity for metrics-reporter pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for metrics pods
+  priorityClassName: ""
 
   ## Example:
   ##
@@ -1681,6 +1694,8 @@ airbyteBootloader:
   # -- Affinity and anti-affinity for bootloader pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for bootloader pods
+  priorityClassName: ""
 
   # -- Security context for the container
   podSecurityContext:
@@ -1899,6 +1914,8 @@ temporal:
   # -- Affinity and anti-affinity for temporal pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for temporal pods
+  priorityClassName: ""
 
   ## Example:
   ##
@@ -2029,6 +2046,8 @@ temporalUi:
   # -- Affinity and anti-affinity for temporal-ui pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for temporal-ui pods
+  priorityClassName: ""
 
   ## Example:
   ##
@@ -2292,6 +2311,8 @@ cron:
   # -- Affinity and anti-affinity for cron pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for cron pods
+  priorityClassName: ""
 
   log:
     # -- The log level to log at.
@@ -2475,6 +2496,8 @@ keycloak:
   # -- Affinity and anti-affinity for webapp pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for keycloak pods
+  priorityClassName: ""
 
   ## Configure extra options for the keycloak containers' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
@@ -2675,6 +2698,8 @@ manifestServer:
   # -- Affinity and anti-affinity for webapp pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: { }
+  # -- Priority class for manifest-server pods
+  priorityClassName: ""
 
   ## Example:
   ## secrets:
@@ -2707,6 +2732,8 @@ workloadApiServer:
 
   # -- workload-api-server replicas
   replicaCount: 1
+  # -- Deployment update strategy type for workload-api-server (Recreate or RollingUpdate)
+  deploymentStrategyType: RollingUpdate
 
   serviceAccountName:
 
@@ -2797,6 +2824,10 @@ workloadApiServer:
   # -- Affinity and anti-affinity for webapp pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for workload-api-server pods
+  priorityClassName: ""
+  # -- Topology spread constraints for workload-api-server pods
+  topologySpreadConstraints: []
 
   env_vars: {}
 
@@ -2843,6 +2874,8 @@ featureflagServer:
 
   # -- workload-api-server replicas
   replicaCount: 1
+  # -- Deployment update strategy type for featureflag-server (Recreate or RollingUpdate)
+  deploymentStrategyType: RollingUpdate
 
   serviceAccountName:
 
@@ -2936,6 +2969,8 @@ featureflagServer:
   # -- Affinity and anti-affinity for webapp pod assignment, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # -- Priority class for featureflag-server pods
+  priorityClassName: ""
 
   env_vars: {}
   service:
@@ -2981,6 +3016,8 @@ testWebapp:
 stiggSidecar:
   enabled: false
   replicaCount: 1
+  # -- Deployment update strategy type for stigg-sidecar (Recreate or RollingUpdate)
+  deploymentStrategyType: RollingUpdate
 
   serviceAccountName:
 
@@ -3049,6 +3086,8 @@ stiggSidecar:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # -- Priority class for stigg-sidecar pods
+  priorityClassName: ""
 
   log:
     level: INFO
@@ -3061,9 +3100,6 @@ stiggSidecar:
   extraContainers: []
 
   env_vars: {}
-
-  hpa:
-    enabled: false
 
   debug:
     enabled: false


### PR DESCRIPTION
## What

Three small, related completions of the chart v2 scheduling surface:

1. `priorityClassName` for all workloads. Every component already exposes `nodeSelector`, `tolerations` and `affinity`; this adds the one standard scheduling field missing everywhere, in the identical guarded shape the existing `nodeSelector` blocks use.
2. `deploymentStrategyType` for the six components that currently hardcode their strategy (workload-launcher, connector-rollout-worker and metrics hardcode `Recreate`; featureflag-server, stigg-sidecar and workload-api-server hardcode `RollingUpdate`). Each new value defaults to the component's current literal, so nothing changes unless an operator opts in. This makes the strategy configurable; it does not change any default behavior.
3. `topologySpreadConstraints` for worker, workload-launcher and workload-api-server, extending the block airbyte-server already has.

Also removes the four `hpa: {enabled: false}` blocks in values.yaml that no template consumes; they read as a supported feature but render nothing.

## Why

Production self-managed clusters using preemption tiers and zone spreading currently cannot express either for most Airbyte components. The strategy knob matters for single-replica components on clusters where `Recreate` downtime windows are policy-relevant, while keeping the safe defaults for components where `Recreate` may be load-bearing.

## How

`priorityClassName` and `topologySpreadConstraints` reuse the existing passthrough patterns already used for `nodeSelector` and `affinity`. Every new value carries a `# --` helm-docs annotation. Renders with default values are unchanged. No changes to autogenerated files under templates/config.
