### PR TITLE
fix(server): add expiry to the remote-definitions-provider cache

### DIFF
--- a/airbyte-server/src/main/resources/application.yml
+++ b/airbyte-server/src/main/resources/application.yml
@@ -18,6 +18,8 @@ micronaut:
       expire-after-write: 10m
     dataplane-group:
       expire-after-write: 10m
+    remote-definitions-provider:
+      expire-after-write: 15s
     platform-compatibility-provider:
       expire-after-write: 15s
     organization-customer-attributes:


### PR DESCRIPTION
## What

Adds a cache expiry for `remote-definitions-provider` (and `platform-compatibility-provider`, which shares the situation) to airbyte-server's application.yml, mirroring the 15s `expire-after-write` that airbyte-cron already configures for the same caches.

## Why

Both airbyte-cron and airbyte-server use `RemoteDefinitionsProvider.getRemoteConnectorRegistry()`, which is `@Cacheable` under the `remote-definitions-provider` cache. airbyte-cron configures that cache with `expire-after-write: 15s`, but airbyte-server does not configure it at all, so the server memoizes its first registry fetch after pod start indefinitely.

Visible effect in the stock UI: on an instance whose server pods have been running for a few days, the connector version information shown in Settings (which is served from `list_latest`) lags behind the definition updates the cron has already applied, until the server pod restarts. Aligning the server's cache configuration with the cron's fixes this with no code change.

## How

One configuration addition under the server's `micronaut.caches` section, matching the cron's existing values. No code changes.
