### PR TITLE
fix(airbyte-oauth): send client_secret at Bing Ads code exchange when configured

### DIFF
--- a/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/flows/MicrosoftBingAdsOAuthFlow.kt
+++ b/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/flows/MicrosoftBingAdsOAuthFlow.kt
@@ -9,6 +9,7 @@ import io.airbyte.commons.annotation.InternalForTesting
 import io.airbyte.oauth.AUTH_CODE_KEY
 import io.airbyte.oauth.BaseOAuth2Flow
 import io.airbyte.oauth.CLIENT_ID_KEY
+import io.airbyte.oauth.CLIENT_SECRET_KEY
 import io.airbyte.oauth.GRANT_TYPE_KEY
 import io.airbyte.oauth.REDIRECT_URI_KEY
 import io.airbyte.oauth.RESPONSE_TYPE_KEY
@@ -67,12 +68,18 @@ class MicrosoftBingAdsOAuthFlow : BaseOAuth2Flow {
     authCode: String,
     redirectUrl: String,
   ): Map<String, String> =
-    mapOf(
-      GRANT_TYPE_KEY to "authorization_code",
-      AUTH_CODE_KEY to authCode,
-      CLIENT_ID_KEY to clientId,
-      REDIRECT_URI_KEY to redirectUrl,
-    )
+    buildMap {
+      put(GRANT_TYPE_KEY, "authorization_code")
+      put(AUTH_CODE_KEY, authCode)
+      put(CLIENT_ID_KEY, clientId)
+      put(REDIRECT_URI_KEY, redirectUrl)
+      // Entra rejects a client_secret on a public-client app (AADSTS700025) and requires one on a
+      // web app (AADSTS7000218). The registered app type is not knowable here, so mirror the
+      // configured credential: send the secret only when one is actually configured.
+      if (clientSecret.isNotBlank()) {
+        put(CLIENT_SECRET_KEY, clientSecret)
+      }
+    }
 
   override fun getAccessTokenUrl(inputOAuthConfiguration: JsonNode): String {
     val tenantId = getConfigValueUnsafe(inputOAuthConfiguration, FIELD_NAME)

--- a/airbyte-oauth/src/test/kotlin/io/airbyte/oauth/flows/MicrosoftBingAdsOAuthFlowTest.kt
+++ b/airbyte-oauth/src/test/kotlin/io/airbyte/oauth/flows/MicrosoftBingAdsOAuthFlowTest.kt
@@ -7,7 +7,22 @@ package io.airbyte.oauth.flows
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.commons.json.Jsons
 import io.airbyte.oauth.BaseOAuthFlow
+import io.airbyte.oauth.CLIENT_ID_KEY
+import io.airbyte.oauth.CLIENT_SECRET_KEY
+import io.airbyte.oauth.GRANT_TYPE_KEY
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
+import java.net.URLDecoder
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.Flow
 
 internal class MicrosoftBingAdsOAuthFlowTest : BaseOAuthFlowTest() {
   override val oAuthFlow: BaseOAuthFlow
@@ -37,5 +52,80 @@ internal class MicrosoftBingAdsOAuthFlowTest : BaseOAuthFlowTest() {
 
   @Test
   override fun testEmptyInputCompleteSourceOAuth() {
+  }
+
+  @Test
+  fun testCompleteSourceOAuthOmitsBlankClientSecret() {
+    val tokenRequestParams = completeSourceOAuthTokenRequestParams("")
+    assertFalse(
+      tokenRequestParams.containsKey(CLIENT_SECRET_KEY),
+      "A blank client secret must not be sent, otherwise Entra rejects a public-client app with AADSTS700025.",
+    )
+    assertEquals("authorization_code", tokenRequestParams[GRANT_TYPE_KEY])
+    assertEquals("test_client_id", tokenRequestParams[CLIENT_ID_KEY])
+  }
+
+  @Test
+  fun testCompleteSourceOAuthSendsConfiguredClientSecret() {
+    val tokenRequestParams = completeSourceOAuthTokenRequestParams("test_client_secret")
+    assertEquals("test_client_secret", tokenRequestParams[CLIENT_SECRET_KEY])
+    assertEquals("authorization_code", tokenRequestParams[GRANT_TYPE_KEY])
+    assertEquals("test_client_id", tokenRequestParams[CLIENT_ID_KEY])
+  }
+
+  /**
+   * Runs the code exchange against the given configured client secret and returns the form-encoded
+   * parameters that were actually posted to the token endpoint.
+   */
+  private fun completeSourceOAuthTokenRequestParams(clientSecret: String): Map<String, String> {
+    val response = mockk<HttpResponse<String>>()
+    every { response.body() } returns mockedResponse
+    val sentRequest = slot<HttpRequest>()
+    every { httpClient.send(capture(sentRequest), any<HttpResponse.BodyHandler<String>>()) } returns response
+
+    oAuthFlow.completeSourceOAuth(
+      UUID.randomUUID(),
+      UUID.randomUUID(),
+      queryParams,
+      REDIRECT_URL,
+      inputOAuthConfiguration,
+      getOauthConfigSpecification(),
+      Jsons.jsonNode(
+        mapOf(
+          CLIENT_ID_KEY to "test_client_id",
+          CLIENT_SECRET_KEY to clientSecret,
+        ),
+      ),
+    )
+
+    return parseFormEncodedBody(readRequestBody(sentRequest.captured))
+  }
+
+  private fun parseFormEncodedBody(body: String): Map<String, String> =
+    body
+      .split("&")
+      .filter { it.isNotEmpty() }
+      .associate {
+        it.substringBefore("=") to URLDecoder.decode(it.substringAfter("="), StandardCharsets.UTF_8)
+      }
+
+  private fun readRequestBody(request: HttpRequest): String {
+    val bodySubscriber = HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8)
+    request.bodyPublisher().orElseThrow().subscribe(
+      object : Flow.Subscriber<ByteBuffer> {
+        override fun onSubscribe(subscription: Flow.Subscription) = bodySubscriber.onSubscribe(subscription)
+
+        override fun onNext(item: ByteBuffer) = bodySubscriber.onNext(listOf(item))
+
+        override fun onError(throwable: Throwable) = bodySubscriber.onError(throwable)
+
+        override fun onComplete() = bodySubscriber.onComplete()
+      },
+    )
+    return bodySubscriber.body.toCompletableFuture().join()
+  }
+
+  companion object {
+    private const val REDIRECT_URL = "https://airbyte.io"
   }
 }


### PR DESCRIPTION
## Problem

`MicrosoftBingAdsOAuthFlow.getAccessTokenQueryParameters` overrides the base implementation in order to add `grant_type=authorization_code`, but in doing so it dropped `client_secret` from the token request entirely. Microsoft Entra decides whether a refresh token is a *public-client* or a *confidential-client* token based on whether the code exchange was authenticated with a secret, so every Bing Ads connection created through this flow has been receiving a public-client refresh token. That distinction matters because Entra revokes public-client refresh tokens as soon as the user changes or resets their password, while confidential-client refresh tokens survive a password change. This is the mechanism behind the recurring "Refresh token is invalid or expired" reports.

This was reproduced against the production Cloud OAuth app on 2026-08-28. A refresh token minted through a public-client exchange returned `400 invalid_grant AADSTS50173` after a self-service password change on the account, while a confidential-client-minted token for that same account returned 200 under identical conditions.

## Why the change is guarded on `isNotBlank()`

The shared Cloud OAuth parameter stores `client_secret: ""`, so for every customer on Airbyte's shared Entra app the `isNotBlank()` check is false and the outgoing request is byte-identical to what it is today. There is no behaviour change and no migration concern for that population — this commit is a no-op for them until the shared app is given a real secret.

What it does fix immediately is customers who supply their own Entra app registration. Today those customers hit one of two dead ends depending on how they registered the app: a public-client registration returns `401 AADSTS700025` because the real secret they configured gets sent at refresh time against an app that forbids one, and a web-app registration returns `400 AADSTS7000218` because the exchange arrives with no secret against an app that requires one. Sending the secret exactly when one is configured resolves both, since the request now mirrors the credential the customer actually supplied. The registered app type is not knowable from inside the flow, so mirroring the configured credential is the only signal available.

## Scope

This is step 1 of a larger fix and does not by itself stop the recurrence, because the shared Cloud app still stores an empty secret and therefore still mints public-client tokens. Making the shared app confidential is separate follow-up work. Tracked in `airbytehq/oncall#12835`.

## Testing

Tests were **not** run. This machine has no Java runtime installed — `./gradlew :oss:airbyte-oauth:test --tests '*MicrosoftBingAds*'` fails immediately with "Unable to locate a Java Runtime" before Gradle starts — and installing a JDK was out of scope for this change. The two new cases in `MicrosoftBingAdsOAuthFlowTest` are therefore unverified locally and need CI to confirm them. They drive `completeSourceOAuth` end to end, capture the `HttpRequest` handed to the mocked `HttpClient`, and parse the form-encoded body: one asserts that a blank configured secret produces a body with no `client_secret` key, the other that a configured secret is present with its value. Both also assert `grant_type` and `client_id` are still sent, which guards the reason the override exists in the first place — the four-argument default in `BaseOAuth2Flow` omits `grant_type`, so deleting the override rather than fixing it would break the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
