### PR TITLE
fix(airbyte-oauth): surface token endpoint HTTP errors instead of masking them

### DIFF
--- a/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/BaseOAuth2Flow.kt
+++ b/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/BaseOAuth2Flow.kt
@@ -437,6 +437,11 @@ abstract class BaseOAuth2Flow
 
       try {
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() >= 400) {
+          throw IOException(
+            "Token endpoint $accessTokenUrl returned HTTP ${response.statusCode()}: ${response.body()}",
+          )
+        }
         return extractOAuthOutput(Jsons.deserialize(response.body()), accessTokenUrl, inputOAuthConfiguration)
       } catch (e: InterruptedException) {
         throw IOException("Failed to complete OAuth flow", e)

--- a/airbyte-oauth/src/test/kotlin/io/airbyte/oauth/BaseOAuth2FlowTest.kt
+++ b/airbyte-oauth/src/test/kotlin/io/airbyte/oauth/BaseOAuth2FlowTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020-2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.oauth
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.commons.json.Jsons
+import io.airbyte.protocol.models.v0.OAuthConfigSpecification
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.net.http.HttpClient
+import java.net.http.HttpResponse
+import java.util.UUID
+
+/**
+ * Tests the token exchange behavior shared by every OAuth2 connector, exercised through a minimal
+ * concrete flow so the assertions cover [BaseOAuth2Flow] itself rather than any one connector.
+ */
+internal class BaseOAuth2FlowTest {
+  private lateinit var httpClient: HttpClient
+  private lateinit var oauthFlow: BaseOAuth2Flow
+
+  @BeforeEach
+  fun setup() {
+    httpClient = mockk()
+    oauthFlow = TestingOAuth2Flow(httpClient)
+  }
+
+  @Test
+  fun testCompleteOAuthSurfacesHttpErrorStatusAndBody() {
+    val errorBody =
+      """{"error":"invalid_grant","error_description":"AADSTS54005: OAuth2 Authorization code was already redeemed"}"""
+    mockHttpResponse(400, errorBody)
+
+    val exception = assertThrows(IOException::class.java) { completeSourceOAuth() }
+    val message = exception.message!!
+
+    assertTrue(message.contains("400"), "Expected the HTTP status in the error message but got: $message")
+    assertTrue(message.contains(errorBody), "Expected the response body in the error message but got: $message")
+    assertTrue(message.contains(ACCESS_TOKEN_URL), "Expected the token endpoint in the error message but got: $message")
+    assertFalse(
+      message.contains("Missing '$REFRESH_TOKEN_KEY'"),
+      "The provider error should surface instead of a missing-refresh_token error, but got: $message",
+    )
+  }
+
+  @Test
+  fun testCompleteOAuthSurfacesServerErrorWithNonJsonBody() {
+    mockHttpResponse(500, "Internal Server Error")
+
+    val exception = assertThrows(IOException::class.java) { completeSourceOAuth() }
+    val message = exception.message!!
+
+    assertTrue(message.contains("500"), "Expected the HTTP status in the error message but got: $message")
+    assertTrue(message.contains("Internal Server Error"), "Expected the raw body in the error message but got: $message")
+  }
+
+  @Test
+  fun testCompleteOAuthSucceedsOnSuccessfulResponse() {
+    mockHttpResponse(200, Jsons.serialize(mapOf(REFRESH_TOKEN_KEY to REFRESH_TOKEN_RESPONSE)))
+
+    val output = completeSourceOAuth()
+
+    assertEquals(REFRESH_TOKEN_RESPONSE, output[REFRESH_TOKEN_KEY])
+  }
+
+  private fun mockHttpResponse(
+    statusCode: Int,
+    body: String,
+  ) {
+    val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns statusCode
+    every { response.body() } returns body
+    every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
+  }
+
+  private fun completeSourceOAuth(): Map<String, Any> =
+    oauthFlow.completeSourceOAuth(
+      UUID.randomUUID(),
+      UUID.randomUUID(),
+      mapOf(AUTH_CODE_KEY to "test_code"),
+      REDIRECT_URL,
+      Jsons.emptyObject(),
+      oauthConfigSpecification,
+      oAuthParamConfig,
+    )
+
+  /**
+   * A minimal OAuth2 flow that keeps the base class behavior intact, so these tests observe the
+   * shared token exchange rather than a connector specific override.
+   */
+  private class TestingOAuth2Flow(
+    httpClient: HttpClient,
+  ) : BaseOAuth2Flow(httpClient) {
+    override fun formatConsentUrl(
+      definitionId: UUID?,
+      clientId: String,
+      redirectUrl: String,
+      inputOAuthConfiguration: JsonNode,
+    ): String = "https://airbyte.io/consent"
+
+    override fun getAccessTokenUrl(inputOAuthConfiguration: JsonNode): String = ACCESS_TOKEN_URL
+  }
+
+  companion object {
+    private const val ACCESS_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    private const val REDIRECT_URL = "https://airbyte.io"
+    private const val REFRESH_TOKEN_RESPONSE = "refresh_token_response"
+    private const val TYPE = "type"
+
+    private val oAuthParamConfig: JsonNode =
+      Jsons.jsonNode(
+        mapOf(
+          CLIENT_ID_KEY to "test_client_id",
+          CLIENT_SECRET_KEY to "test_client_secret",
+        ),
+      )
+
+    private val oauthConfigSpecification: OAuthConfigSpecification =
+      OAuthConfigSpecification()
+        .withCompleteOauthOutputSpecification(
+          getJsonSchema(mapOf(REFRESH_TOKEN_KEY to mapOf(TYPE to "string"))),
+        ).withCompleteOauthServerOutputSpecification(
+          getJsonSchema(mapOf(CLIENT_ID_KEY to mapOf(TYPE to "string"))),
+        )
+
+    private fun getJsonSchema(properties: Map<String, Any>): JsonNode =
+      Jsons.jsonNode(
+        mapOf(
+          TYPE to "object",
+          "additionalProperties" to "false",
+          "properties" to properties,
+        ),
+      )
+  }
+}

--- a/airbyte-oauth/src/test/kotlin/io/airbyte/oauth/flows/BaseOAuthFlowTest.kt
+++ b/airbyte-oauth/src/test/kotlin/io/airbyte/oauth/flows/BaseOAuthFlowTest.kt
@@ -471,6 +471,7 @@ abstract class BaseOAuthFlowTest {
   open fun testDeprecatedCompleteSourceOAuth() {
     val returnedCredentials = expectedOutput
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns Jsons.serialize(returnedCredentials)
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -508,6 +509,7 @@ abstract class BaseOAuthFlowTest {
   open fun testDeprecatedCompleteDestinationOAuth() {
     val returnedCredentials = expectedOutput
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns Jsons.serialize(returnedCredentials)
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -557,6 +559,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testEmptyOutputCompleteSourceOAuth() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -580,6 +583,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testEmptyOutputCompleteDestinationOAuth() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -603,6 +607,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testEmptyInputCompleteSourceOAuth() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -633,6 +638,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testEmptyInputCompleteDestinationOAuth() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -663,6 +669,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testCompleteSourceOAuth() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -693,6 +700,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testCompleteDestinationOAuth() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams
@@ -723,6 +731,7 @@ abstract class BaseOAuthFlowTest {
   @Test
   open fun testValidateOAuthOutputFailure() {
     val response = mockk<HttpResponse<String>>()
+    every { response.statusCode() } returns 200
     every { response.body() } returns mockedResponse
     every { httpClient.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns response
     val queryParams = queryParams


### PR DESCRIPTION
## What

When an OAuth flow completes, `BaseOAuth2Flow.getCompleteOAuthFlowOutput` sends the token request and hands the response body straight to `extractOAuthOutput` without ever checking the HTTP status. When the provider returns a 4xx, the body is an error document rather than a token payload, so `extractOAuthOutput` simply notices the token is absent and throws `Missing 'refresh_token' in query params from <url>`.

That message is actively misleading. It points at our own parsing rather than the provider's rejection, and it discards the response body — the only place the real cause is written down. For Microsoft Entra that body carries the `AADSTS` code, which is the single most diagnostic field the provider gives us; today it never reaches logs or the user.

This change inspects the status code and throws an `IOException` that names the token endpoint and carries the status and the response body.

## Scope

This is the shared completion path for every OAuth connector built on `BaseOAuth2Flow`, so the fix is not Microsoft-specific — every connector using the base implementation currently masks provider errors the same way. Connectors that build their own token request (Shopify, Snowflake, Pinterest, Xero, Facebook and a handful of others) are untouched; notably `ShopifyOAuthFlow` already hand-rolls this exact status check, which is decent evidence the base class should have been doing it all along.

It is also a prerequisite for diagnosing `airbytehq/oncall#12835`. Across 300 sampled production failure summaries there, zero `AADSTS` codes appear — not because the provider withheld them, but because this code path throws them away before anything gets logged. Without this fix there is nothing to analyze.

## Error handling detail

The enclosing `try` has exactly one `catch`, for `InterruptedException`, so the new `IOException` is not caught, re-wrapped, or swallowed. It propagates with its message and the response body intact.

## Tests

Added `BaseOAuth2FlowTest`, which drives the shared token exchange through a minimal concrete flow so the assertions cover the base class rather than any single connector. It asserts that a 400 surfaces the status code and the response body (and specifically *not* a missing-`refresh_token` error), that a 500 with a non-JSON body surfaces the raw body, and that a successful 200 still returns the token.

The new status check means `statusCode()` is now called on every response, and the existing mocks in `BaseOAuthFlowTest` are strict `mockk` mocks that only stubbed `body()`. Those nine mocks now also stub `statusCode()` as 200; without that, every inherited completion test would fail on an unstubbed call.

**Tests were not run.** This machine has no JDK — `./gradlew :oss:airbyte-oauth:test` fails with "Unable to locate a Java Runtime" — so the change and its tests are unverified locally and rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)