### PR TITLE
fix(metrics-reporter): add ksp so Micronaut bean definitions are generated

### DIFF
--- a/airbyte-metrics/reporter/build.gradle.kts
+++ b/airbyte-metrics/reporter/build.gradle.kts
@@ -9,6 +9,8 @@ configurations {
 }
 
 dependencies {
+  ksp(platform(libs.micronaut.platform))
+  ksp(libs.bundles.micronaut.annotation.processor)
 
   implementation(platform(libs.micronaut.platform))
   implementation(libs.bundles.micronaut)


### PR DESCRIPTION
# fix(metrics-reporter): use ksp so Micronaut bean definitions are generated

## What

Add the Micronaut KSP annotation processor to
`airbyte-metrics/reporter/build.gradle.kts`.

```diff
 dependencies {
+  ksp(platform(libs.micronaut.platform))
+  ksp(libs.bundles.micronaut.annotation.processor)
 
   implementation(platform(libs.micronaut.platform))
```

On `main` the module has **no** annotation processor configured at all. It had
`annotationProcessor(...)` (the javac configuration, inert against Kotlin
sources) through 2.0.x; those lines have since been removed without a `ksp`
replacement. Either way, nothing has processed this module's annotations since
the Kotlin conversion.

## Why

The module was converted from Java to Kotlin in 1.8.0 but kept the javac
annotation-processor configuration, which does not apply to Kotlin sources.
Micronaut's processor has produced nothing since, so the published jar contains
no `$Definition` classes and no `META-INF/micronaut/` index — from 1.8.0 through
2.2.0 it holds only the 18 raw Kotlin classes.

Micronaut resolves beans from those compile-time artifacts, so at runtime none of
the emitters or `EventListeners` exist. The service starts, connects to the
database, starts its OTLP publisher and emits nothing, with no error. Confirmed on
a running 2.0.1 instance: `/beans` lists 603 definitions and zero from
`io.airbyte.metrics.reporter`, and `registered N emitters` never logs.

Every other Kotlin Micronaut module in this repo already uses `ksp(...)` —
`airbyte-cron`, `airbyte-server`, `airbyte-workload-launcher`. This brings the
reporter in line.

## Testing

- `./gradlew :oss:airbyte-metrics:reporter:build`
- Confirm the jar contains `$Definition` classes and `META-INF/micronaut/`
- Run the service and confirm it logs `registered 11 emitters` at startup

`kspTest` is deliberately not added: the module's tests use no `@MicronautTest`.
- Confirm metrics arrive at the configured OTLP endpoint

Fixes https://github.com/airbytehq/airbyte/issues/85345
