### PR TITLE
fix(security): pin OpenTelemetry javaagent to v2.27.0

### DIFF
--- a/airbyte-base-java-image/Dockerfile
+++ b/airbyte-base-java-image/Dockerfile
@@ -25,7 +25,8 @@ EOF
 ADD --chown=airbyte:airbyte https://dtdg.co/latest-java-tracer dd-java-agent.jar
 
 # Add the OpenTelemetry Java APM agent
-ADD --chown=airbyte:airbyte https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
+# Pinned to v2.27.0 to fix CVE-2026-33701, CVE-2026-54712 (was pulling "latest" unpinned)
+ADD --chown=airbyte:airbyte https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.27.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 ADD --chown=airbyte:airbyte entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
…, CVE-2026-54712)

In an effort to focus our support efforts on connector contributions, we no longer accept community PRs in this repository.

Please report issues to: https://github.com/airbytehq/airbyte

All of our other public repos remain open to contribution! We look forward to working with you.
