### PR TITLE
fix(security): upgrade jinjava 2.7.4 → 2.7.6

### DIFF
--- a/airbyte-oauth/build.gradle.kts
+++ b/airbyte-oauth/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   implementation(libs.google.cloud.storage)
   implementation(libs.aws.java.sdk.s3)
   implementation(libs.aws.java.sdk.sts)
-  implementation("com.hubspot.jinjava:jinjava:2.7.4")
+  implementation("com.hubspot.jinjava:jinjava:2.7.6") // Upgraded from 2.7.4 to fix CVE-2025-59340, CVE-2026-25526
 
   implementation(project(":oss:airbyte-api:problems-api"))
   implementation(project(":oss:airbyte-commons"))


### PR DESCRIPTION
…6-25526)

In an effort to focus our support efforts on connector contributions, we no longer accept community PRs in this repository.

Please report issues to: https://github.com/airbytehq/airbyte

All of our other public repos remain open to contribution! We look forward to working with you.
